### PR TITLE
Add event portfolio assets and manifest generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "manifest:cleanup": "node scripts/cleanup-manifests.js",
     "manifest:cleanup-preview": "node scripts/cleanup-manifests.js --dry",
     "manifest:journalism": "node scripts/generate-journalism-manifest-v2.js",
+    "manifest:events": "node scripts/generate-events-manifest.js",
     "watch:journalism-manifest": "node scripts/watch-journalism-manifest.js",
     "organize:concerts": "node scripts/auto-concert-organizer.js --auto",
     "organize:preview": "node scripts/auto-concert-organizer.js --auto --dry",

--- a/scripts/generate-events-manifest.js
+++ b/scripts/generate-events-manifest.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/**
+ * Event Portfolio Manifest Generator
+ *
+ * Scans src/images/Portfolios/Events for event folders and produces
+ * events-manifest.json mirroring the schema used for journalism manifests.
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+
+const EVENTS_DIR = path.join(__dirname, '../src/images/Portfolios/Events');
+const MANIFEST_PATH = path.join(EVENTS_DIR, 'events-manifest.json');
+const SUPPORTED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp'];
+
+function isImageFile(filename) {
+  const ext = path.extname(filename).toLowerCase();
+  return SUPPORTED_EXTENSIONS.includes(ext);
+}
+
+function cleanTitle(name) {
+  return name
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, letter => letter.toUpperCase());
+}
+
+function extractDateFromFilename(filename) {
+  const patterns = [
+    /(\d{6})_/, // 241105_EventName_
+    /(\d{6})-/, // 241105-EventName-
+    /^(\d{6})/ // 241105EventName
+  ];
+
+  for (const pattern of patterns) {
+    const match = filename.match(pattern);
+    if (!match) continue;
+
+    const value = match[1];
+    const year = 2000 + parseInt(value.substring(0, 2), 10);
+    const month = parseInt(value.substring(2, 4), 10);
+    const day = parseInt(value.substring(4, 6), 10);
+
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day) {
+      return date.toISOString().split('T')[0];
+    }
+  }
+
+  return null;
+}
+
+function formatDisplayDate(iso) {
+  if (!iso) return 'Date TBD';
+  const date = new Date(iso);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+}
+
+async function ensureEventsDirExists() {
+  try {
+    await fs.access(EVENTS_DIR);
+  } catch (error) {
+    throw new Error(`Events directory not found: ${EVENTS_DIR}`);
+  }
+}
+
+async function collectEventData() {
+  const entries = await fs.readdir(EVENTS_DIR, { withFileTypes: true });
+  const events = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const eventFolder = entry.name;
+    const eventDir = path.join(EVENTS_DIR, eventFolder);
+    const files = await fs.readdir(eventDir);
+    const imageFiles = files.filter(isImageFile).sort();
+
+    if (imageFiles.length === 0) {
+      // Skip empty folders to keep manifest clean
+      continue;
+    }
+
+    const eventName = cleanTitle(eventFolder);
+    let eventDateIso = null;
+    let eventDateSource = null;
+
+    for (const filename of imageFiles) {
+      const extracted = extractDateFromFilename(filename);
+      if (extracted) {
+        eventDateIso = extracted;
+        eventDateSource = 'filename_extraction';
+        break;
+      }
+    }
+
+    if (!eventDateIso) {
+      eventDateIso = new Date().toISOString().split('T')[0];
+      eventDateSource = 'fallback_current_date';
+    }
+
+    const images = imageFiles.map(filename => ({
+      filename,
+      path: `${eventFolder}/${filename}`,
+      description: `${eventName} photography`,
+      caption: `${eventName}`,
+      tags: ['Events']
+    }));
+
+    events.push({
+      eventName,
+      category: 'Events',
+      tags: ['Events'],
+      folderPath: eventFolder,
+      eventDate: {
+        iso: eventDateIso,
+        source: eventDateSource
+      },
+      dateDisplay: formatDisplayDate(eventDateIso),
+      totalImages: images.length,
+      images,
+      published: false,
+      metadata: {}
+    });
+  }
+
+  // Sort events newest first by date
+  events.sort((a, b) => (a.eventDate.iso < b.eventDate.iso ? 1 : -1));
+  return events;
+}
+
+async function buildManifest(events) {
+  const totalImages = events.reduce((sum, event) => sum + event.totalImages, 0);
+
+  return {
+    version: '2.0',
+    generated: new Date().toISOString(),
+    totalEvents: events.length,
+    totalImages,
+    events
+  };
+}
+
+async function writeManifest(manifest) {
+  const content = `${JSON.stringify(manifest, null, 2)}\n`;
+  await fs.writeFile(MANIFEST_PATH, content, 'utf-8');
+}
+
+async function main() {
+  try {
+    await ensureEventsDirExists();
+    const events = await collectEventData();
+    const manifest = await buildManifest(events);
+    await writeManifest(manifest);
+    console.log(`✅ Generated ${manifest.totalEvents} events with ${manifest.totalImages} images`);
+  } catch (error) {
+    console.error('❌ Failed to generate events manifest:', error.message);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/src/images/Portfolios/Events/Charity-Gala-2024/241105_Charity_Gala_Auction.jpg
+++ b/src/images/Portfolios/Events/Charity-Gala-2024/241105_Charity_Gala_Auction.jpg
@@ -1,0 +1,1 @@
+Placeholder image for Charity-Gala-2024

--- a/src/images/Portfolios/Events/Charity-Gala-2024/241105_Charity_Gala_Ballroom.jpg
+++ b/src/images/Portfolios/Events/Charity-Gala-2024/241105_Charity_Gala_Ballroom.jpg
@@ -1,0 +1,1 @@
+Placeholder image for Charity-Gala-2024

--- a/src/images/Portfolios/Events/Charity-Gala-2024/241105_Charity_Gala_Red_Carpet.jpg
+++ b/src/images/Portfolios/Events/Charity-Gala-2024/241105_Charity_Gala_Red_Carpet.jpg
@@ -1,0 +1,1 @@
+Placeholder image for Charity-Gala-2024

--- a/src/images/Portfolios/Events/Corporate-Summit-2025/250315_Corporate_Summit_Keynote.jpg
+++ b/src/images/Portfolios/Events/Corporate-Summit-2025/250315_Corporate_Summit_Keynote.jpg
@@ -1,0 +1,1 @@
+Placeholder image for Corporate-Summit-2025

--- a/src/images/Portfolios/Events/Corporate-Summit-2025/250315_Corporate_Summit_Panel.jpg
+++ b/src/images/Portfolios/Events/Corporate-Summit-2025/250315_Corporate_Summit_Panel.jpg
@@ -1,0 +1,1 @@
+Placeholder image for Corporate-Summit-2025

--- a/src/images/Portfolios/Events/Product-Launch-Expo-2025/250620_Product_Launch_Expo_Demo.jpg
+++ b/src/images/Portfolios/Events/Product-Launch-Expo-2025/250620_Product_Launch_Expo_Demo.jpg
@@ -1,0 +1,1 @@
+Placeholder image for Product-Launch-Expo-2025

--- a/src/images/Portfolios/Events/Product-Launch-Expo-2025/250620_Product_Launch_Expo_Showcase.jpg
+++ b/src/images/Portfolios/Events/Product-Launch-Expo-2025/250620_Product_Launch_Expo_Showcase.jpg
@@ -1,0 +1,1 @@
+Placeholder image for Product-Launch-Expo-2025

--- a/src/images/Portfolios/Events/events-manifest.json
+++ b/src/images/Portfolios/Events/events-manifest.json
@@ -1,6 +1,125 @@
 {
-  "version": "1.0",
-  "generated": "2025-09-19T05:39:00.000Z",
-  "totalEvents": 0,
-  "events": []
+  "version": "2.0",
+  "generated": "2025-09-25T21:27:14.497Z",
+  "totalEvents": 3,
+  "totalImages": 7,
+  "events": [
+    {
+      "eventName": "Product Launch Expo 2025",
+      "category": "Events",
+      "tags": [
+        "Events"
+      ],
+      "folderPath": "Product-Launch-Expo-2025",
+      "eventDate": {
+        "iso": "2025-06-20",
+        "source": "filename_extraction"
+      },
+      "dateDisplay": "June 20, 2025",
+      "totalImages": 2,
+      "images": [
+        {
+          "filename": "250620_Product_Launch_Expo_Demo.jpg",
+          "path": "Product-Launch-Expo-2025/250620_Product_Launch_Expo_Demo.jpg",
+          "description": "Product Launch Expo 2025 photography",
+          "caption": "Product Launch Expo 2025",
+          "tags": [
+            "Events"
+          ]
+        },
+        {
+          "filename": "250620_Product_Launch_Expo_Showcase.jpg",
+          "path": "Product-Launch-Expo-2025/250620_Product_Launch_Expo_Showcase.jpg",
+          "description": "Product Launch Expo 2025 photography",
+          "caption": "Product Launch Expo 2025",
+          "tags": [
+            "Events"
+          ]
+        }
+      ],
+      "published": false,
+      "metadata": {}
+    },
+    {
+      "eventName": "Corporate Summit 2025",
+      "category": "Events",
+      "tags": [
+        "Events"
+      ],
+      "folderPath": "Corporate-Summit-2025",
+      "eventDate": {
+        "iso": "2025-03-15",
+        "source": "filename_extraction"
+      },
+      "dateDisplay": "March 15, 2025",
+      "totalImages": 2,
+      "images": [
+        {
+          "filename": "250315_Corporate_Summit_Keynote.jpg",
+          "path": "Corporate-Summit-2025/250315_Corporate_Summit_Keynote.jpg",
+          "description": "Corporate Summit 2025 photography",
+          "caption": "Corporate Summit 2025",
+          "tags": [
+            "Events"
+          ]
+        },
+        {
+          "filename": "250315_Corporate_Summit_Panel.jpg",
+          "path": "Corporate-Summit-2025/250315_Corporate_Summit_Panel.jpg",
+          "description": "Corporate Summit 2025 photography",
+          "caption": "Corporate Summit 2025",
+          "tags": [
+            "Events"
+          ]
+        }
+      ],
+      "published": false,
+      "metadata": {}
+    },
+    {
+      "eventName": "Charity Gala 2024",
+      "category": "Events",
+      "tags": [
+        "Events"
+      ],
+      "folderPath": "Charity-Gala-2024",
+      "eventDate": {
+        "iso": "2024-11-05",
+        "source": "filename_extraction"
+      },
+      "dateDisplay": "November 5, 2024",
+      "totalImages": 3,
+      "images": [
+        {
+          "filename": "241105_Charity_Gala_Auction.jpg",
+          "path": "Charity-Gala-2024/241105_Charity_Gala_Auction.jpg",
+          "description": "Charity Gala 2024 photography",
+          "caption": "Charity Gala 2024",
+          "tags": [
+            "Events"
+          ]
+        },
+        {
+          "filename": "241105_Charity_Gala_Ballroom.jpg",
+          "path": "Charity-Gala-2024/241105_Charity_Gala_Ballroom.jpg",
+          "description": "Charity Gala 2024 photography",
+          "caption": "Charity Gala 2024",
+          "tags": [
+            "Events"
+          ]
+        },
+        {
+          "filename": "241105_Charity_Gala_Red_Carpet.jpg",
+          "path": "Charity-Gala-2024/241105_Charity_Gala_Red_Carpet.jpg",
+          "description": "Charity Gala 2024 photography",
+          "caption": "Charity Gala 2024",
+          "tags": [
+            "Events"
+          ]
+        }
+      ],
+      "published": false,
+      "metadata": {}
+    }
+  ]
 }

--- a/src/widgets/event-portfolio/README.md
+++ b/src/widgets/event-portfolio/README.md
@@ -25,32 +25,58 @@ Professional event photography portfolio widget for displaying corporate events,
 images/Portfolios/Events/
 ├── events-manifest.json (REQUIRED - single API call!)
 ├── Corporate-Summit-2025/
-│   ├── image1.jpg
-│   └── image2.jpg
-├── Tech-Conference/
-│   ├── keynote.jpg
-│   └── networking.jpg
-└── Wedding-Reception/
-    ├── ceremony.jpg
-    └── reception.jpg
+│   ├── 250315_Corporate_Summit_Keynote.jpg
+│   └── 250315_Corporate_Summit_Panel.jpg
+├── Charity-Gala-2024/
+│   ├── 241105_Charity_Gala_Auction.jpg
+│   ├── 241105_Charity_Gala_Ballroom.jpg
+│   └── 241105_Charity_Gala_Red_Carpet.jpg
+└── Product-Launch-Expo-2025/
+    ├── 250620_Product_Launch_Expo_Demo.jpg
+    └── 250620_Product_Launch_Expo_Showcase.jpg
 ```
 
 #### Manifest Format
 ```json
 {
-  "version": "1.0",
+  "version": "2.0",
   "generated": "2025-09-19T05:39:00.000Z",
   "totalEvents": 2,
+  "totalImages": 4,
   "events": [
     {
       "eventName": "Corporate Summit 2025",
+      "category": "Events",
+      "tags": ["Events"],
       "folderPath": "Corporate-Summit-2025",
-      "dateDisplay": "March 2025",
+      "eventDate": {
+        "iso": "2025-03-15",
+        "source": "filename_extraction"
+      },
+      "dateDisplay": "March 15, 2025",
       "totalImages": 2,
-      "images": ["image1.jpg", "image2.jpg"]
+      "images": [
+        {
+          "filename": "250315_Corporate_Summit_Keynote.jpg",
+          "path": "Corporate-Summit-2025/250315_Corporate_Summit_Keynote.jpg",
+          "description": "Corporate Summit 2025 photography",
+          "caption": "Corporate Summit 2025",
+          "tags": ["Events"]
+        }
+      ],
+      "published": false,
+      "metadata": {}
     }
   ]
 }
+```
+
+#### Regenerating the Manifest
+
+Run the automation script after adding or removing event folders or images:
+
+```bash
+npm run manifest:events
 ```
 
 ### Debug Mode


### PR DESCRIPTION
## Summary
- add representative event folders and placeholder images that match production naming
- generate an updated events manifest with the journalism-style schema
- create a Node.js script and npm script to regenerate the events manifest and document the workflow in the widget README

## Testing
- npm run manifest:events

------
https://chatgpt.com/codex/tasks/task_b_68d5b31fdfdc83269ee61496ca713c24