### PR TITLE
Polish event portfolio v2.0 debug telemetry

### DIFF
--- a/src/widgets/event-portfolio/CHANGELOG.md
+++ b/src/widgets/event-portfolio/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Event Portfolio widget.
 
+## v2.0 (2025-09-20) — Smart Sync & Event Ops Console 🎟️
+### Live Experience Enhancements ✨
+- **NEW**: LocalStorage-backed manifest cache with a 10-minute TTL to keep galleries fast and resilient.
+- **NEW**: 15-minute auto-refresh cadence with countdown badge so producers know the next sync.
+- **NEW**: On-brand changelog modal and v2.0 badge to communicate release notes to stakeholders.
+- **NEW**: Event Operations debug console surfaces cache source, sync timing, manifest version, and API call metrics.
+
+### Reliability Improvements 🔁
+- **Single manifest flow preserved** ensuring image paths continue to load from `src/images/Portfolios/Events/`.
+- **Force refresh logic** skips cache on demand for auto-refresh or tab re-activation scenarios.
+- **Live cache age ticker** keeps producers informed about how fresh the manifest data is during long monitoring sessions.
+- **Graceful fallback messaging** for manifest outages with event-centric copy.
+
+---
+
 ## v1.1 (2025-09-19) — Single Manifest API Call 🚀
 ### Ultra-Efficient Performance Revolution ⚡
 - **NEW**: Single API call approach using `events-manifest.json` (no rate limiting needed!)

--- a/src/widgets/event-portfolio/README.md
+++ b/src/widgets/event-portfolio/README.md
@@ -4,23 +4,25 @@ Professional event photography portfolio widget for displaying corporate events,
 
 ## Features
 
+- **Smart manifest caching** keeps galleries fast with a 10-minute freshness window
+- **15-minute auto-refresh cadence** with live countdown badge for event control rooms
+- **Modal changelog + version badge** to communicate release notes on-brand
 - **Event-focused design** with professional purple-blue color scheme
 - **Universal Caption System integration** for consistent metadata handling
-- **GitHub API integration** for automatic event discovery
+- **GitHub manifest integration** for automatic event discovery via single fetch
 - **Natural-height masonry layout** optimized for event photography
 - **Enhanced lightbox** with professional event context
-- **Performance optimized** with intelligent caching and lazy loading
-- **Debug mode** with event-specific metrics
+- **Event Ops debug console** surfaces cache source, sync timing, manifest version, and API metrics
 - **Mobile responsive** with adaptive grid layout
 
 ## Usage
 
 ### Squarespace Integration
 ```html
-<!-- Copy and paste the entire v1.1-manifest.html file into a Code Block -->
+<!-- Copy and paste the entire v2.0-manifest.html file into a Code Block -->
 ```
 
-### GitHub Structure (v1.1 Manifest Approach)
+### GitHub Structure (v2.0 Smart Sync)
 ```
 images/Portfolios/Events/
 ├── events-manifest.json (REQUIRED - single API call!)
@@ -54,9 +56,9 @@ images/Portfolios/Events/
 ```
 
 ### Debug Mode
-- Click the "🔧 Debug Mode" button to view performance metrics
-- Monitor load times, event count, and Universal Caption System status
-- Mobile-friendly debug panel positioning
+- Click the "🛠️ Event Ops Console" button to open the debug panel
+- Monitor cache source, API call count, sync timing, and Universal Caption System status
+- Countdown badge in the lower corner shows time until the next auto-refresh
 
 ## Styling
 
@@ -80,5 +82,6 @@ images/Portfolios/Events/
 
 ## Version History
 
+- **v2.0** (2025-09-20): Smart manifest cache, auto-refresh cadence, changelog modal, and Event Ops console
 - **v1.1** (2025-09-19): Single manifest API call approach - ultra-efficient performance
 - **v1.0** (2025-09-19): Initial release with full event portfolio functionality

--- a/src/widgets/event-portfolio/versions/v2.0-manifest.html
+++ b/src/widgets/event-portfolio/versions/v2.0-manifest.html
@@ -1,0 +1,900 @@
+<!-- Event Portfolio v2.0 — Smart Manifest Caching + Event Ops Console -->
+Author: Caleb McCartney / McCal-Codes
+Version: 2.0 Smart Sync & Refresh
+Features:
+ - LocalStorage-backed manifest cache with 10-minute freshness window
+ - Single manifest fetch pipeline retained for reliability
+ - 15-minute intelligent auto-refresh with live countdown badge
+ - Modal changelog with on-brand event copy and version badge
+ - Event Operations debug console with cache + sync insights
+ - Enhanced lightbox leveraging Universal Caption System metadata
+ - Natural-height masonry layout tuned for event photography
+
+Usage: Paste this entire block into a Squarespace Code Block
+GitHub Structure: images/Portfolios/Events/events-manifest.json + [Event folders]
+Brand Voice: Corporate Events • Conferences • Celebrations • Special Occasions
+-->
+
+<!-- Load Universal Caption System -->
+<script src="https://cdn.jsdelivr.net/gh/McCal-Codes/McCals-Website@main/widgets/shared/universal-caption-system.js"></script>
+
+<style>
+  :root {
+    --fg:#f5f5f5;
+    --bg:#0a0a0a;
+    --line:#2a2a2a;
+    --accent:#4d79ff; /* Blue accent for events */
+    --event-primary:#6366f1; /* Event purple-blue */
+    --event-secondary:#8b5cf6; /* Complementary purple */
+    --event-pop:#22d3ee; /* Countdown accent */
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --fg:#0a0a0a;
+      --bg:#fff;
+      --line:#e5e5e5;
+      --accent:#3b82f6;
+      --event-primary:#4f46e5;
+      --event-secondary:#7c3aed;
+      --event-pop:#0891b2;
+    }
+  }
+
+  .event-portfolio { max-width:1600px; margin:60px auto; padding:40px 20px; text-align:center; position:relative; }
+  .event-heading {
+    font:800 34px/1.2 ui-sans-serif,system-ui;
+    color:var(--fg);
+    margin:0 0 8px;
+    background: linear-gradient(135deg, var(--event-primary), var(--event-secondary));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  .event-subtitle {
+    font:400 16px/1.4 ui-sans-serif,system-ui;
+    color:var(--fg);
+    opacity: 0.75;
+    margin:0 0 32px;
+  }
+
+  /* Loading states */
+  .event-loading {
+    display: flex; align-items: center; justify-content: center; min-height: 200px;
+    font: 600 16px/1.4 ui-sans-serif,system-ui; color: var(--fg); opacity: 0.7;
+  }
+  .event-spinner {
+    width: 20px; height: 20px; border: 2px solid var(--line); border-top: 2px solid var(--event-primary);
+    border-radius: 50%; animation: spin 1s linear infinite; margin-right: 12px;
+  }
+  @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+
+  /* Auto-refresh indicator */
+  .auto-refresh-indicator {
+    position: fixed;
+    bottom: 8px;
+    right: 56px;
+    font: 600 10px/1 ui-sans-serif,system-ui;
+    color: rgba(128, 148, 255, 0.7);
+    pointer-events: none;
+    z-index: 1000;
+    letter-spacing: 0.02em;
+  }
+
+  /* Version indicator */
+  .version-indicator {
+    position: fixed;
+    bottom: 8px;
+    right: 16px;
+    font: 700 10px/1 ui-sans-serif,system-ui;
+    color: rgba(99, 102, 241, 0.85);
+    cursor: pointer;
+    z-index: 1000;
+    transition: color 0.2s ease, transform 0.2s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .version-indicator:hover {
+    color: var(--event-pop);
+    transform: translateY(-1px);
+  }
+
+  /* Debug Toggle Button */
+  .debug-toggle {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(99, 102, 241, 0.4);
+    color: var(--fg);
+    padding: 8px 18px;
+    border-radius: 18px;
+    cursor: pointer;
+    font: 600 12px/1 ui-sans-serif,system-ui;
+    z-index: 1000;
+    transition: all 0.3s ease;
+    box-shadow: 0 12px 32px rgba(79, 70, 229, 0.2);
+  }
+  .debug-toggle:hover {
+    background: rgba(30, 41, 59, 0.95);
+    opacity: 0.95;
+  }
+
+  /* Debug info panel */
+  .debug-info {
+    position: fixed;
+    bottom: 64px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(15, 23, 42, 0.92);
+    color: #e2e8f0;
+    padding: 14px 18px;
+    border-radius: 12px;
+    font: 600 11px/1.4 ui-monospace,monospace;
+    z-index: 999;
+    max-width: 520px;
+    border: 1px solid rgba(99, 102, 241, 0.45);
+    display: none;
+    backdrop-filter: blur(16px);
+    box-shadow: 0 18px 48px rgba(15, 23, 42, 0.45);
+  }
+  .debug-info.active { display: block; }
+
+  /* Natural-height Masonry */
+  .event-grid {
+    column-width:320px; column-gap:20px; text-align:left; opacity:0; transition:opacity 0.5s ease;
+  }
+  .event-grid.loaded { opacity: 1; }
+  @media (max-width:1024px) { .event-grid { column-width:280px } }
+  @media (max-width:768px) { .event-grid { column-width:240px } }
+  @media (max-width:520px) { .event-grid { column-width:100% } }
+
+  .event-card {
+    position:relative; display:inline-block; width:100%; margin:0 0 20px;
+    background:linear-gradient(145deg, #1a1a2e, #16213e);
+    border-radius:16px; overflow:hidden; cursor:pointer; break-inside:avoid;
+    opacity:0; transform:translateY(20px); transition:all 0.35s ease;
+    border: 1px solid rgba(79, 70, 229, 0.25);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.4);
+  }
+  .event-card.loaded { opacity: 1; transform: translateY(0); }
+  .event-card:hover {
+    border-color: rgba(79, 70, 229, 0.5);
+    box-shadow: 0 24px 48px rgba(79, 70, 229, 0.25);
+  }
+  .event-card img {
+    display:block; width:100%; height:auto; object-fit:contain; border-radius:inherit;
+    transition:transform .35s ease, filter .35s ease;
+  }
+  .event-card:hover img { transform:scale(1.02); filter:contrast(1.05) saturate(1.1) brightness(1.05) }
+
+  .event-info {
+    position:absolute; left:0; right:0; bottom:0; display:flex; flex-direction:column; justify-content:flex-end;
+    padding:12px 16px;
+    background:linear-gradient(180deg,rgba(79, 70, 229, 0),rgba(79, 70, 229, 0.05) 35%, rgba(16, 33, 62, .92));
+    color:#fff
+  }
+  .event-title { margin:0; font:800 16px/1.2 ui-sans-serif,system-ui; color: #e0e7ff; }
+  .event-meta { margin:4px 0 0; font:600 12px/1.2 ui-sans-serif,system-ui; color:#c7d2fe; }
+
+  /* Loading states */
+  .event-card.loading::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+    background: linear-gradient(90deg, transparent, rgba(79, 70, 229, 0.15), transparent);
+    animation: shimmer 1.5s infinite;
+  }
+  @keyframes shimmer { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
+
+  .event-card.error { background: #2a1a1a; border: 1px solid #4a2a2a; }
+  .event-card.error::after {
+    content: '⚠️'; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    font-size: 24px; opacity: 0.5;
+  }
+
+  /* Enhanced Lightbox with Caption Support */
+  .event-lightbox {
+    position:fixed; inset:0; display:none; align-items:center; justify-content:center;
+    background:rgba(16, 33, 62, 0.9); z-index:2147483647 !important; padding:24px;
+    backdrop-filter: blur(12px);
+  }
+  .event-lightbox.is-open { display:flex }
+  .el-dialog { position:relative; max-width:95vw; max-height:92vh; overflow:auto; background:transparent; outline:none }
+  .el-gallery { display:flex; flex-direction:column; gap:20px; overflow-y:auto; scroll-snap-type:y mandatory; padding-right:12px }
+  .el-gallery img {
+    max-width:92vw; max-height:75vh; width:auto; height:auto; scroll-snap-align:center;
+    border-radius:14px; margin:0 auto; transition:opacity 0.3s ease;
+    box-shadow: 0 8px 32px rgba(79, 70, 229, 0.3);
+  }
+  .el-gallery img.loading { opacity: 0.7; }
+  .el-gallery img.loaded { opacity: 1; }
+
+  .el-caption { text-align:center; color:#fff; margin-top:16px; padding:0 20px; }
+  .el-title { margin:0 0 8px; font:800 20px/1.25 ui-sans-serif,system-ui; color: #e0e7ff; }
+  .el-meta { margin:0 0 12px; color:#c7d2fe; font:600 13px/1.3 ui-sans-serif,system-ui }
+  .el-description { margin:0; color:#f1f5f9; font:400 15px/1.5 ui-sans-serif,system-ui }
+  .el-source { margin:8px 0 0; color:#94a3b8; font:500 11px/1.2 ui-sans-serif,system-ui; opacity:0.7; }
+
+  .el-close {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    border: 1px solid rgba(79, 70, 229, 0.3);
+    background: rgba(16, 33, 62, 0.6);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    color: rgba(224, 231, 255, 0.9);
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 20px rgba(79, 70, 229, 0.3), inset 0 1px 0 rgba(224, 231, 255, 0.2);
+    z-index: 2147483648;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .el-close:hover {
+    background: rgba(79, 70, 229, 0.4);
+    color: rgba(255, 255, 255, 1);
+    transform: scale(1.05);
+    border-color: rgba(79, 70, 229, 0.5);
+  }
+
+  .el-hint {
+    position: sticky;
+    top: 6px;
+    margin: 0 0 10px;
+    text-align: center;
+    font: 500 12px/1.2 ui-sans-serif,system-ui;
+    color: #94a3b8;
+    opacity: 0.7;
+  }
+
+  @media (max-width: 768px) {
+    .event-card { margin-bottom: 16px; }
+    .event-heading { font-size: 28px; }
+    .debug-toggle, .debug-info { display: none; }
+    .auto-refresh-indicator, .version-indicator { position: static; display: inline-block; margin: 12px 8px 0; }
+    .event-portfolio { padding: 32px 16px; }
+  }
+</style>
+
+<div class="event-portfolio" id="eventPf" data-panes="12">
+  <h2 class="event-heading">Event Portfolio</h2>
+  <p class="event-subtitle">Corporate Events • Conferences • Celebrations • Special Occasions</p>
+
+  <div class="event-loading" id="eventLoading">
+    <div class="event-spinner"></div>
+    Loading event highlights...
+  </div>
+  <div class="event-grid" id="eventGrid"></div>
+</div>
+
+<div class="event-lightbox" id="eventLightbox" aria-hidden="true">
+  <div class="el-dialog" role="dialog" aria-modal="true" aria-labelledby="elLbTitle" tabindex="-1">
+    <button class="el-close" onclick="closeEventLightbox()" aria-label="Close">&times;</button>
+    <div class="el-gallery" id="elGallery"></div>
+  </div>
+</div>
+
+<!-- Version indicator + countdown -->
+<div class="version-indicator" onclick="showChangelog()" title="View event release notes">v2.0</div>
+<div class="auto-refresh-indicator" id="autoRefreshIndicator">Next sync: --</div>
+
+<!-- Changelog Modal -->
+<div class="changelog-modal" id="changelogModal">
+  <div class="changelog-content">
+    <div class="changelog-header">
+      <h3 class="changelog-title">🎟️ Event Portfolio Release Notes</h3>
+      <button class="changelog-close" onclick="hideChangelog()" aria-label="Close changelog">&times;</button>
+    </div>
+    <div class="changelog-body">
+      <div class="changelog-version">v2.0 – Smart Sync & Event Ops Console (Current)</div>
+      <ul class="changelog-items">
+        <li>10-minute manifest caching keeps event galleries fast without sacrificing freshness.</li>
+        <li>15-minute auto-refresh cadence with live countdown badge for production control.</li>
+        <li>On-brand changelog modal plus v2.0 badge for stakeholders.</li>
+        <li>Event Operations debug console highlights cache source, sync timing, and API activity.</li>
+      </ul>
+
+      <div class="changelog-version">v1.1 – Single Manifest Rollout</div>
+      <ul class="changelog-items">
+        <li>Unified manifest fetch powering all event galleries.</li>
+        <li>Universal Caption System integration for metadata consistency.</li>
+        <li>Event styling refresh with upgraded lightbox experience.</li>
+      </ul>
+
+      <div class="changelog-version">v1.0 – Launch</div>
+      <ul class="changelog-items">
+        <li>Initial grid layout for curated event storytelling.</li>
+        <li>Manual refresh workflow and baseline debug metrics.</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<!-- Debug Toggle Button -->
+<button class="debug-toggle" onclick="toggleDebug()">🛠️ Event Ops Console</button>
+
+<!-- Debug info panel -->
+<div class="debug-info" id="debugInfo">
+  <div style="margin-bottom: 10px; color: var(--event-pop); font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em;">Event Ops Console v2.0</div>
+  <div>Status: <span id="debugStatus">Booting</span></div>
+  <div>Sync Source: <span id="debugSource">--</span></div>
+  <div>Events Online: <span id="debugEventCount">--</span></div>
+  <div>Cards Rendered: <span id="debugImageCount">--</span></div>
+  <div>Manifest Version: <span id="debugManifestVersion">--</span></div>
+  <div>API Calls: <span id="debugApiCalls">--</span></div>
+  <div>Cache Age: <span id="debugCacheAge">--</span></div>
+  <div>Last Sync: <span id="debugLastRefresh">--</span></div>
+  <div>Auto-Refresh: <span id="debugAutoRefresh">15 min cadence</span></div>
+</div>
+
+<style>
+  .changelog-modal {
+    position: fixed; inset: 0; background: rgba(10, 10, 10, 0.75); display: none;
+    align-items: center; justify-content: center; z-index: 1200; padding: 20px;
+    backdrop-filter: blur(12px);
+  }
+  .changelog-modal.active { display: flex; }
+  .changelog-content {
+    background: var(--bg); border: 1px solid var(--line); border-radius: 16px;
+    max-width: 520px; width: 100%; max-height: 70vh; overflow-y: auto; position: relative;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.5);
+  }
+  .changelog-header {
+    padding: 22px; border-bottom: 1px solid var(--line); display: flex;
+    align-items: center; justify-content: space-between;
+  }
+  .changelog-title {
+    margin: 0; color: var(--fg); font: 700 18px/1.2 ui-sans-serif, system-ui;
+    letter-spacing: 0.04em; text-transform: uppercase;
+  }
+  .changelog-close {
+    background: none; border: none; color: var(--fg); font-size: 22px;
+    cursor: pointer; padding: 4px 8px; border-radius: 8px; transition: background 0.2s ease;
+  }
+  .changelog-close:hover { background: rgba(99, 102, 241, 0.15); }
+  .changelog-body {
+    padding: 22px; font: 400 14px/1.6 ui-sans-serif, system-ui; color: var(--fg);
+  }
+  .changelog-version {
+    margin: 0 0 12px 0; color: var(--fg); font: 600 15px/1.3 ui-sans-serif, system-ui;
+    border-bottom: 1px solid var(--line); padding-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em;
+  }
+  .changelog-items {
+    margin: 12px 0 24px; padding-left: 18px;
+  }
+  .changelog-items li {
+    margin: 6px 0; color: rgba(229, 231, 235, 0.85);
+  }
+</style>
+
+<script>
+let debugActive = false;
+let debugMetrics = {
+  startTime: performance.now(),
+  apiCalls: 0,
+  eventCount: 0,
+  imageCount: 0,
+  lastRefresh: '--',
+  lastSource: '--',
+  cacheAge: '--',
+  manifestVersion: '--'
+};
+
+const AUTO_REFRESH_INTERVAL = 15 * 60 * 1000; // 15 minutes
+const CACHE_DURATION = 10 * 60 * 1000; // 10 minutes
+const CACHE_KEY = 'event-manifest-cache-v2';
+let autoRefreshTimer = null;
+let countdownTimer = null;
+let isTabVisible = !document.hidden;
+let lastVisibilityChange = Date.now();
+let cacheAgeTicker = null;
+
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return '--';
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes <= 0) {
+    return `${seconds}s`;
+  }
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+}
+
+function getPanesCount(element) {
+  if (!element) return 12;
+  const panesAttr = element.getAttribute('data-panes');
+  const parsed = parseInt(panesAttr, 10);
+  return Math.max(1, Number.isFinite(parsed) ? parsed : 12);
+}
+
+function setDebugText(id, value) {
+  const el = document.getElementById(id);
+  if (el) {
+    el.textContent = value;
+  }
+}
+
+function toggleDebug() {
+  debugActive = !debugActive;
+  const debugPanel = document.getElementById('debugInfo');
+  if (debugPanel) {
+    debugPanel.classList.toggle('active', debugActive);
+    if (debugActive) {
+      updateDebugMetrics();
+    }
+  }
+}
+
+function updateDebugMetrics() {
+  const loadTime = Math.round(performance.now() - debugMetrics.startTime);
+  const statusEl = document.getElementById('debugStatus');
+  if (statusEl && statusEl.textContent === 'Booting') {
+    statusEl.textContent = 'Ready';
+  }
+  setDebugText('debugEventCount', debugMetrics.eventCount);
+  setDebugText('debugImageCount', `${debugMetrics.imageCount} cards · ${loadTime}ms`);
+  setDebugText('debugManifestVersion', debugMetrics.manifestVersion);
+  setDebugText('debugApiCalls', debugMetrics.apiCalls);
+  setDebugText('debugLastRefresh', debugMetrics.lastRefresh);
+  setDebugText('debugSource', debugMetrics.lastSource);
+  setDebugText('debugCacheAge', debugMetrics.cacheAge);
+}
+
+function updateNextRefreshIndicator() {
+  const indicator = document.getElementById('autoRefreshIndicator');
+  if (!indicator) return;
+
+  if (countdownTimer) {
+    clearTimeout(countdownTimer);
+    countdownTimer = null;
+  }
+
+  let timeLeft = AUTO_REFRESH_INTERVAL;
+  const tick = () => {
+    if (timeLeft <= 0) {
+      indicator.textContent = 'Syncing…';
+    } else {
+      const minutes = Math.floor(timeLeft / 60000);
+      const seconds = Math.floor((timeLeft % 60000) / 1000);
+      indicator.textContent = `Next sync: ${minutes}:${seconds.toString().padStart(2, '0')}`;
+    }
+
+    if (timeLeft > 0) {
+      timeLeft -= 1000;
+      countdownTimer = setTimeout(tick, 1000);
+    }
+  };
+
+  tick();
+}
+
+function stopCacheAgeTicker() {
+  if (cacheAgeTicker) {
+    clearInterval(cacheAgeTicker);
+    cacheAgeTicker = null;
+  }
+}
+
+function showChangelog() {
+  const modal = document.getElementById('changelogModal');
+  if (modal) {
+    modal.classList.add('active');
+    document.body.style.overflow = 'hidden';
+  }
+}
+
+function hideChangelog() {
+  const modal = document.getElementById('changelogModal');
+  if (modal) {
+    modal.classList.remove('active');
+    document.body.style.overflow = '';
+  }
+}
+
+// Close changelog on background click
+window.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('changelogModal');
+  if (modal) {
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) {
+        hideChangelog();
+      }
+    });
+  }
+});
+
+// Close changelog on Escape key
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    const modal = document.getElementById('changelogModal');
+    if (modal && modal.classList.contains('active')) {
+      hideChangelog();
+    }
+  }
+});
+
+(function() {
+  const YEAR = new Date().getFullYear();
+  const pf = document.getElementById('eventPf');
+  const grid = document.getElementById('eventGrid');
+  const loading = document.getElementById('eventLoading');
+  const debugStatus = document.getElementById('debugStatus');
+
+  if (!grid) return;
+
+  const TARGET_PANES = getPanesCount(pf);
+
+  function logDebug(message, data = null) {
+    if (debugActive) {
+      console.log(`[Event Debug v2.0] ${message}`, data || '');
+      if (debugStatus) {
+        debugStatus.textContent = message;
+        updateDebugMetrics();
+      }
+    }
+  }
+
+  function getCachedManifest() {
+    try {
+      const cached = localStorage.getItem(CACHE_KEY);
+      if (cached) {
+        const data = JSON.parse(cached);
+        const age = Date.now() - data.timestamp;
+        if (age < CACHE_DURATION) {
+          logDebug('Serving manifest from cache', `Age: ${Math.round(age / 1000)}s`);
+          return { manifest: data.manifest, age, timestamp: data.timestamp };
+        }
+      }
+    } catch (error) {
+      logDebug('Cache read error', error.message);
+    }
+    return null;
+  }
+
+  function setCachedManifest(manifest) {
+    try {
+      const data = {
+        manifest,
+        timestamp: Date.now()
+      };
+      localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+      logDebug('Manifest cached successfully');
+    } catch (error) {
+      logDebug('Cache write error', error.message);
+    }
+  }
+
+  // GitHub configuration - SINGLE MANIFEST SOURCE
+  const GH = { owner:'McCal-Codes', repo:'McCals-Website', branch:'main' };
+  const rawBase = `https://raw.githubusercontent.com/${GH.owner}/${GH.repo}/${GH.branch}/`;
+  const manifestUrl = rawBase + 'src/images/Portfolios/Events/events-manifest.json';
+
+  function rawUrl(parts) {
+    return rawBase + 'src/images/Portfolios/Events/' + parts.map(encodeURIComponent).join('/');
+  }
+
+  async function loadMasterManifest(forceRefresh = false) {
+    if (!forceRefresh) {
+      const cached = getCachedManifest();
+      if (cached && cached.manifest) {
+        debugMetrics.lastSource = 'Cache';
+        debugMetrics.cacheAge = formatDuration(cached.age);
+        debugMetrics.lastRefresh = new Date(cached.timestamp).toLocaleTimeString();
+        debugMetrics.manifestVersion = cached.manifest.version || 'unversioned';
+        startCacheAgeTicker(cached.timestamp);
+        return cached.manifest;
+      }
+    }
+
+    debugMetrics.apiCalls++;
+    logDebug('Fetching manifest from GitHub...');
+
+    const response = await fetch(manifestUrl, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const manifest = await response.json();
+    setCachedManifest(manifest);
+    debugMetrics.lastSource = 'Live fetch';
+    debugMetrics.cacheAge = 'fresh';
+    const now = Date.now();
+    debugMetrics.lastRefresh = new Date(now).toLocaleTimeString();
+    debugMetrics.manifestVersion = manifest.version || 'unversioned';
+    startCacheAgeTicker(now);
+    return manifest;
+  }
+
+  function shuffle(arr) {
+    const a = arr.slice();
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+  }
+
+  function createEventCard(imageSrc, title, meta, index, allImages, eventData) {
+    const card = document.createElement('article');
+    card.className = 'event-card loading';
+    card.tabIndex = 0;
+    card.dataset.dir = eventData.folderPath;
+
+    const img = document.createElement('img');
+    img.loading = 'lazy';
+    img.decoding = 'async';
+    img.alt = `${title} event photo`;
+
+    const info = document.createElement('div');
+    info.className = 'event-info';
+    info.innerHTML = `
+      <h3 class="event-title">${title}</h3>
+      <p class="event-meta">${meta}</p>
+    `;
+
+    card.appendChild(img);
+    card.appendChild(info);
+
+    const handleLoaded = () => {
+      card.classList.remove('loading');
+      card.classList.add('loaded');
+      debugMetrics.imageCount += 1;
+      updateDebugMetrics();
+    };
+
+    img.addEventListener('load', handleLoaded);
+    img.addEventListener('error', () => {
+      card.classList.remove('loading');
+      card.classList.add('error');
+    });
+
+    setTimeout(() => {
+      img.src = imageSrc;
+    }, index * 80);
+
+    const openLightbox = () => openEventLightbox(allImages, eventData);
+    card.addEventListener('click', openLightbox);
+    card.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openLightbox();
+      }
+    });
+
+    return card;
+  }
+
+  function openEventLightbox(images, eventData) {
+    const lightbox = document.getElementById('eventLightbox');
+    const gallery = document.getElementById('elGallery');
+
+    if (!lightbox || !gallery) return;
+
+    gallery.innerHTML = '<div class="el-hint">Scroll ↓ to review full event story</div>';
+
+    images.forEach((imageName, idx) => {
+      const img = document.createElement('img');
+      img.className = 'loading';
+      img.loading = 'lazy';
+      img.decoding = 'async';
+      img.alt = `${eventData.eventName} – Image ${idx + 1}`;
+      img.src = rawUrl(eventData.folderPath.split('/').concat([imageName]));
+
+      img.addEventListener('load', () => {
+        img.classList.remove('loading');
+        img.classList.add('loaded');
+      });
+
+      gallery.appendChild(img);
+    });
+
+    const caption = document.createElement('div');
+    caption.className = 'el-caption';
+    caption.innerHTML = `
+      <h3 class="el-title" id="elLbTitle">${eventData.eventName}</h3>
+      <div class="el-meta">${eventData.dateDisplay} • ${images.length} photos</div>
+      <div class="el-description">${eventData.description || 'Signature event coverage with storytelling moments and candid energy.'}</div>
+      <div class="el-source">Powered by Universal Caption System • McCal Media Events</div>
+    `;
+    gallery.appendChild(caption);
+
+    lightbox.classList.add('is-open');
+    lightbox.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+
+    const hint = gallery.querySelector('.el-hint');
+    if (hint && images.length > 1) {
+      setTimeout(() => hint.style.opacity = '0', 3000);
+    }
+  }
+
+  window.closeEventLightbox = function() {
+    const lightbox = document.getElementById('eventLightbox');
+    if (lightbox) {
+      lightbox.classList.remove('is-open');
+      lightbox.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
+    }
+  };
+
+  const lightboxOverlay = document.getElementById('eventLightbox');
+  if (lightboxOverlay) {
+    lightboxOverlay.addEventListener('click', (e) => {
+      if (e.target === lightboxOverlay) {
+        window.closeEventLightbox();
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      const lightbox = document.getElementById('eventLightbox');
+      if (lightbox && lightbox.classList.contains('is-open')) {
+        window.closeEventLightbox();
+      }
+    }
+  });
+
+  function buildGridSlots(events) {
+    const pools = events.map(event => ({
+      dir: event.folderPath,
+      parts: event.folderPath.split('/'),
+      title: event.eventName,
+      dateDisplay: event.dateDisplay,
+      images: shuffle(event.images.slice()),
+      allImages: event.images.slice(),
+      eventData: event
+    }));
+
+    const slots = [];
+    let progress = true;
+
+    while (slots.length < TARGET_PANES && progress) {
+      progress = false;
+      for (const pool of pools) {
+        if (slots.length >= TARGET_PANES) break;
+        const nextImage = pool.images.shift();
+        if (nextImage) {
+          slots.push({
+            image: nextImage,
+            title: pool.title,
+            dateDisplay: pool.dateDisplay,
+            parts: pool.parts,
+            allImages: pool.allImages,
+            eventData: pool.eventData
+          });
+          progress = true;
+        }
+      }
+    }
+
+    return slots;
+  }
+
+  async function build(forceRefresh = false) {
+    debugMetrics.startTime = performance.now();
+    debugMetrics.imageCount = 0;
+
+    try {
+      if (loading) {
+        loading.style.display = 'flex';
+        loading.innerHTML = `
+          <div class="event-spinner"></div>
+          Syncing event manifest...
+        `;
+      }
+      const indicator = document.getElementById('autoRefreshIndicator');
+      if (indicator) {
+        indicator.textContent = 'Syncing…';
+      }
+      grid.classList.remove('loaded');
+
+      if (debugStatus) {
+        debugStatus.textContent = forceRefresh ? 'Force refresh running…' : 'Loading manifest…';
+      }
+
+      const manifest = await loadMasterManifest(forceRefresh);
+      debugMetrics.manifestVersion = manifest.version || 'unversioned';
+
+      if (!manifest || !manifest.events || manifest.events.length === 0) {
+        throw new Error('No event data found in manifest.');
+      }
+
+      debugMetrics.eventCount = manifest.events.length;
+
+      const slots = buildGridSlots(manifest.events);
+      if (!slots.length) {
+        throw new Error('No event imagery available from manifest.');
+      }
+
+      grid.innerHTML = '';
+      const fragment = document.createDocumentFragment();
+
+      slots.forEach((slot, index) => {
+        const imageSrc = rawUrl(slot.parts.concat([slot.image]));
+        const meta = `${slot.dateDisplay} • ${YEAR}`;
+        const card = createEventCard(imageSrc, slot.title, meta, index, slot.allImages, slot.eventData);
+        fragment.appendChild(card);
+      });
+
+      grid.appendChild(fragment);
+
+      if (loading) {
+        loading.style.display = 'none';
+      }
+
+      requestAnimationFrame(() => {
+        grid.classList.add('loaded');
+      });
+
+      debugMetrics.lastRefresh = new Date().toLocaleTimeString();
+      updateDebugMetrics();
+      updateNextRefreshIndicator();
+      logDebug('Event grid refreshed successfully', `${slots.length} cards, source: ${debugMetrics.lastSource}`);
+    } catch (error) {
+      console.error('Event portfolio failed:', error);
+      if (loading) {
+        loading.style.display = 'flex';
+        loading.innerHTML = `
+          <div style="color: var(--accent); font-weight: 600;">⚠️ Event gallery temporarily unavailable</div>
+          <div style="margin-top: 8px; font-size: 14px; opacity: 0.8;">${error.message}</div>
+        `;
+      }
+      if (debugStatus) {
+        debugStatus.textContent = `Error: ${error.message}`;
+      }
+      const indicator = document.getElementById('autoRefreshIndicator');
+      if (indicator) {
+        indicator.textContent = 'Sync paused';
+      }
+      stopCacheAgeTicker();
+    }
+  }
+
+  function startCacheAgeTicker(startTimestamp) {
+    stopCacheAgeTicker();
+    cacheAgeTicker = setInterval(() => {
+      const age = Date.now() - startTimestamp;
+      debugMetrics.cacheAge = formatDuration(age);
+      setDebugText('debugCacheAge', debugMetrics.cacheAge);
+    }, 1000);
+  }
+
+  function setupAutoRefresh() {
+    if (autoRefreshTimer) {
+      clearInterval(autoRefreshTimer);
+    }
+
+    document.addEventListener('visibilitychange', () => {
+      const wasVisible = isTabVisible;
+      isTabVisible = !document.hidden;
+      const now = Date.now();
+
+      if (!isTabVisible) {
+        lastVisibilityChange = now;
+      } else if (!wasVisible && now - lastVisibilityChange > AUTO_REFRESH_INTERVAL) {
+        build(true);
+      }
+    });
+
+    autoRefreshTimer = setInterval(() => {
+      if (isTabVisible) {
+        build(true);
+      }
+    }, AUTO_REFRESH_INTERVAL);
+  }
+
+  build().then(() => {
+    setupAutoRefresh();
+    updateNextRefreshIndicator();
+  }).catch(() => {
+    setupAutoRefresh();
+  });
+})();
+</script>


### PR DESCRIPTION
## Summary
- add manifest version readout plus a live cache-age ticker to the Event Ops console
- polish the auto-refresh countdown indicator so it shows sync-in-progress states and always restarts cleanly
- document the richer debug telemetry in the README and changelog for the v2.0 widget

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5afff1ebc832699297607080dd869