### PR TITLE
Refine unified portfolio metadata presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,21 @@
 - Reduced motion support for users preferring less animation.
 
 <!-- ...existing code... -->
+// ...existing code...
+
+## 1.5.0 — 2025-09-29
+- Added unified-portfolio-demo.html (master demo with ?type= and ?manifest=).
+- Links to unified versions for Concert, Event, and Photojournalism.
+
+
+## 1.5.1 — 2025-09-29
+- Refined the unified portfolio theme to mirror the live Work section aesthetic with warm neutrals and uppercase headings.
+- Updated unified widget cards to surface venue/tag metadata with graceful date fallbacks from the manifest.
+
+## 1.5.2 — 2025-09-30
+- Shifted the unified portfolio experience to a monochrome gradient palette with minimal accenting for a darker presentation.
+- Moved card titles and dates into on-image overlays so each gallery mirrors the live Concert layout.
+
+## 1.5.3 — 2025-09-30
+- Rebuilt the unified portfolio layout with full-width imagery, vertical scrolling, and shuffled ordering so each view spotlights only a few shots at a time.
+- Updated unified widgets to respect original asset proportions and manifest metadata without overlay cropping.

--- a/scripts/win-generate-universal-manifest.ps1
+++ b/scripts/win-generate-universal-manifest.ps1
@@ -1,0 +1,8 @@
+param(
+  [string]$Root = ".\src\images\Portfolios",
+  [string]$Out = ".\src\images\Portfolios\portfolio-manifest.json"
+)
+
+Write-Host "Generating universal manifest..."
+node .\scripts\generate-universal-manifest.js --root "$Root" --out "$Out"
+Write-Host "Done -> $Out"

--- a/src/images/Portfolios/portfolio-manifest.json
+++ b/src/images/Portfolios/portfolio-manifest.json
@@ -1,25 +1,26 @@
 {
   "version": "1.0",
-  "generated": "2025-09-19T06:36:31.766Z",
+  "generated": "2025-09-30T04:02:32.751Z",
   "totalPortfolios": 3,
-  "totalItems": 11,
-  "totalImages": 122,
+  "totalItems": 18,
+  "totalImages": 190,
   "categories": [
     "Concert Photography",
+    "Event Photography",
     "Journalism"
   ],
   "portfolioSummary": {
     "Concert": {
-      "count": 10,
-      "totalImages": 120
+      "count": 11,
+      "totalImages": 125
     },
     "Events": {
-      "count": 0,
-      "totalImages": 0
+      "count": 5,
+      "totalImages": 53
     },
     "Journalism": {
-      "count": 1,
-      "totalImages": 2
+      "count": 2,
+      "totalImages": 12
     }
   },
   "items": [
@@ -125,19 +126,18 @@
         "year": 2025,
         "month": 8,
         "monthName": "August",
-        "day": 1,
-        "iso": "2025-08-01"
+        "day": 20,
+        "iso": "2025-08-20",
+        "source": "filename_yymmdd"
       },
-      "totalImages": 12,
+      "totalImages": 10,
       "images": [
         "250820_Haven Block Party_CAL3068.jpg",
         "250820_Haven Block Party_CAL3110.jpg",
         "250820_Haven Block Party_CAL3152.jpg",
-        "250820_Haven Block Party_CAL3154.jpg",
         "250820_Haven Block Party_CAL3200.jpg",
         "250820_Haven Block Party_CAL3236.jpg",
         "250820_Haven Block Party_CAL3253.jpg",
-        "250820_Haven Block Party_CAL3255.jpg",
         "250820_Haven Block Party_CAL3269.jpg",
         "250820_Haven Block Party_CAL3277.jpg",
         "250820_Haven Block Party_CAL3281.jpg",
@@ -155,26 +155,20 @@
         "year": 2025,
         "month": 8,
         "monthName": "August",
-        "day": 1,
-        "iso": "2025-08-01"
+        "day": 20,
+        "iso": "2025-08-20",
+        "source": "filename_yymmdd"
       },
-      "totalImages": 15,
+      "totalImages": 8,
       "images": [
         "250820_Haven Block Party_CAL3301.jpg",
         "250820_Haven Block Party_CAL3304.jpg",
         "250820_Haven Block Party_CAL3315.jpg",
         "250820_Haven Block Party_CAL3351.jpg",
         "250820_Haven Block Party_CAL3364.jpg",
-        "250820_Haven Block Party_CAL3379.jpg",
-        "250820_Haven Block Party_CAL3381.jpg",
         "250820_Haven Block Party_CAL3390.jpg",
-        "250820_Haven Block Party_CAL3405.jpg",
-        "250820_Haven Block Party_CAL3408.jpg",
         "250820_Haven Block Party_CAL3411.jpg",
-        "250820_Haven Block Party_CAL3425.jpg",
-        "250820_Haven Block Party_CAL3429.jpg",
-        "250820_Haven Block Party_CAL3443.jpg",
-        "250820_Haven Block Party_CAL3493.jpg"
+        "250820_Haven Block Party_CAL3443.jpg"
       ],
       "coverImage": "250820_Haven Block Party_CAL3301.jpg"
     },
@@ -188,8 +182,9 @@
         "year": 2025,
         "month": 8,
         "monthName": "August",
-        "day": 1,
-        "iso": "2025-08-01"
+        "day": 20,
+        "iso": "2025-08-20",
+        "source": "filename_yymmdd"
       },
       "totalImages": 9,
       "images": [
@@ -215,8 +210,9 @@
         "year": 2025,
         "month": 8,
         "monthName": "August",
-        "day": 1,
-        "iso": "2025-08-01"
+        "day": 20,
+        "iso": "2025-08-20",
+        "source": "filename_yymmdd"
       },
       "totalImages": 19,
       "images": [
@@ -245,6 +241,39 @@
     {
       "type": "Concert",
       "category": "Concert Photography",
+      "name": "Dream The Heavy",
+      "folderPath": "Concert/Dream The Heavy/April 2025",
+      "dateDisplay": "April 2025",
+      "date": {
+        "year": 2025,
+        "month": 4,
+        "monthName": "April",
+        "day": 4,
+        "iso": "2025-04-04",
+        "source": "filename_yymmdd"
+      },
+      "totalImages": 14,
+      "images": [
+        "250404 Haven Concert_CAL1915.jpg",
+        "250404 Haven Concert_CAL1919.jpg",
+        "250404 Haven Concert_CAL1992.jpg",
+        "250404 Haven Concert_CAL2036.jpg",
+        "250404 Haven Concert_CAL2041.jpg",
+        "250404 Haven Concert_CAL2157.jpg",
+        "250404 Haven Concert_CAL2190.jpg",
+        "250404 Haven Concert_CAL2238.jpg",
+        "250404 Haven Concert_CAL2243.jpg",
+        "250404 Haven Concert_CAL2282.jpg",
+        "250404 Haven Concert_CAL2349.jpg",
+        "250404 Haven Concert_CAL2368.jpg",
+        "250404 Haven Concert_CAL8785.jpg",
+        "250404 Haven Concert_CAL8787.jpg"
+      ],
+      "coverImage": "250404 Haven Concert_CAL1915.jpg"
+    },
+    {
+      "type": "Concert",
+      "category": "Concert Photography",
       "name": "Funky Lamp",
       "folderPath": "Concert/Funky Lamp/April 2024",
       "dateDisplay": "April 2024",
@@ -252,8 +281,9 @@
         "year": 2024,
         "month": 4,
         "monthName": "April",
-        "day": 1,
-        "iso": "2024-04-01"
+        "day": 20,
+        "iso": "2024-04-20",
+        "source": "exif_original"
       },
       "totalImages": 6,
       "images": [
@@ -276,8 +306,9 @@
         "year": 2024,
         "month": 3,
         "monthName": "March",
-        "day": 1,
-        "iso": "2024-03-01"
+        "day": 15,
+        "iso": "2024-03-15",
+        "source": "filename_yymmdd"
       },
       "totalImages": 5,
       "images": [
@@ -299,8 +330,9 @@
         "year": 2024,
         "month": 3,
         "monthName": "March",
-        "day": 1,
-        "iso": "2024-03-01"
+        "day": 15,
+        "iso": "2024-03-15",
+        "source": "filename_yymmdd"
       },
       "totalImages": 19,
       "images": [
@@ -327,10 +359,83 @@
       "coverImage": "240315_Genesis Volume 1_464.jpg"
     },
     {
+      "type": "Events",
+      "category": "Event Photography",
+      "name": "Product Launch Expo 2025",
+      "folderPath": "Events/Product-Launch-Expo-2025",
+      "dateDisplay": "June 2020",
+      "date": {
+        "day": 25,
+        "month": 6,
+        "year": 2020,
+        "monthName": "June",
+        "iso": "2020-06-25",
+        "source": "ddmmyy_solid"
+      },
+      "totalImages": 2,
+      "images": [
+        "250620_Product_Launch_Expo_Demo.jpg",
+        "250620_Product_Launch_Expo_Showcase.jpg"
+      ],
+      "coverImage": "250620_Product_Launch_Expo_Demo.jpg"
+    },
+    {
       "type": "Journalism",
       "category": "Journalism",
-      "name": "Journalism Portfolio",
-      "folderPath": "Journalism",
+      "name": "Events",
+      "folderPath": "Journalism/Events/The Rooney Rule",
+      "dateDisplay": "April 2017",
+      "date": {
+        "day": 25,
+        "month": 4,
+        "year": 2017,
+        "monthName": "April",
+        "iso": "2017-04-25",
+        "source": "ddmmyy_solid"
+      },
+      "totalImages": 1,
+      "images": [
+        "250417 The Rooney Rule_CAL3148.jpg"
+      ],
+      "coverImage": "250417 The Rooney Rule_CAL3148.jpg"
+    },
+    {
+      "type": "Events",
+      "category": "Event Photography",
+      "name": "Pennsylvania Media Awards 24",
+      "folderPath": "Events/pennsylvania-media-awards-24",
+      "dateDisplay": "April 2016",
+      "date": {
+        "day": 24,
+        "month": 4,
+        "year": 2016,
+        "monthName": "April",
+        "iso": "2016-04-24",
+        "source": "ddmmyy_solid"
+      },
+      "totalImages": 13,
+      "images": [
+        "240416-pennsylvania-media-awards-892-published.jpg",
+        "240416-pennsylvania-media-awards-893-published.jpg",
+        "240416-pennsylvania-media-awards-894-published.jpg",
+        "240416-pennsylvania-media-awards-895-published.jpg",
+        "240416-pennsylvania-media-awards-896-published.jpg",
+        "240416-pennsylvania-media-awards-897-published.jpg",
+        "240416-pennsylvania-media-awards-898-published.jpg",
+        "240416-pennsylvania-media-awards-899-published.jpg",
+        "240416-pennsylvania-media-awards-902-published.jpg",
+        "240416-pennsylvania-media-awards-903-published.jpg",
+        "240416-pennsylvania-media-awards-906-published.jpg",
+        "240416-pennsylvania-media-awards-907-published.jpg",
+        "240416-pennsylvania-media-awards-980-published.jpg"
+      ],
+      "coverImage": "240416-pennsylvania-media-awards-892-published.jpg"
+    },
+    {
+      "type": "Events",
+      "category": "Event Photography",
+      "name": "Corporate Summit 2025",
+      "folderPath": "Events/Corporate-Summit-2025",
       "dateDisplay": "March 2015",
       "date": {
         "day": 25,
@@ -342,10 +447,114 @@
       },
       "totalImages": 2,
       "images": [
-        "250315_Butler Democracy Protest_CAL9773.jpg",
-        "250417 The Rooney Rule_CAL3148.jpg"
+        "250315_Corporate_Summit_Keynote.jpg",
+        "250315_Corporate_Summit_Panel.jpg"
       ],
-      "coverImage": "250315_Butler Democracy Protest_CAL9773.jpg"
+      "coverImage": "250315_Corporate_Summit_Keynote.jpg"
+    },
+    {
+      "type": "Journalism",
+      "category": "Journalism",
+      "name": "Politics",
+      "folderPath": "Journalism/Politics/Butler Protest",
+      "dateDisplay": "March 2015",
+      "date": {
+        "day": 25,
+        "month": 3,
+        "year": 2015,
+        "monthName": "March",
+        "iso": "2015-03-25",
+        "source": "ddmmyy_solid"
+      },
+      "totalImages": 11,
+      "images": [
+        "250315_Butler Democracy Protest_CAL9640-min.jpg",
+        "250315_Butler Democracy Protest_CAL9666-min.jpg",
+        "250315_Butler Democracy Protest_CAL9674-min.jpg",
+        "250315_Butler Democracy Protest_CAL9703-min.jpg",
+        "250315_Butler Democracy Protest_CAL9709-min.jpg",
+        "250315_Butler Democracy Protest_CAL9717-min.jpg",
+        "250315_Butler Democracy Protest_CAL9739-min.jpg",
+        "250315_Butler Democracy Protest_CAL9759-min.jpg",
+        "250315_Butler Democracy Protest_CAL9773-min.jpg",
+        "250315_Butler Democracy Protest_CAL9825-min.jpg",
+        "250315_Butler Democracy Protest_CAL9832-min.jpg"
+      ],
+      "coverImage": "250315_Butler Democracy Protest_CAL9640-min.jpg"
+    },
+    {
+      "type": "Events",
+      "category": "Event Photography",
+      "name": "CMU Business Graduation",
+      "folderPath": "Events/CMU-Business-Graduation",
+      "dateDisplay": "May 2011",
+      "date": {
+        "day": 25,
+        "month": 5,
+        "year": 2011,
+        "monthName": "May",
+        "iso": "2011-05-25",
+        "source": "ddmmyy_solid"
+      },
+      "totalImages": 33,
+      "images": [
+        "250511_CMU-Business-Graduation-_CAL6485-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6485-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6485-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6526-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6526-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6526-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6532-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6532-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6532-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6561-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6561-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6561-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6572-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6572-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6572-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6622-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6622-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6622-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6655-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6655-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6655-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6681-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6681-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6681-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6691-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6691-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6691-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6694-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6694-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6694-640.jpg",
+        "250511_CMU-Business-Graduation-_CAL6697-1280.jpg",
+        "250511_CMU-Business-Graduation-_CAL6697-320.jpg",
+        "250511_CMU-Business-Graduation-_CAL6697-640.jpg"
+      ],
+      "coverImage": "250511_CMU-Business-Graduation-_CAL6485-1280.jpg"
+    },
+    {
+      "type": "Events",
+      "category": "Event Photography",
+      "name": "Charity Gala 2024",
+      "folderPath": "Events/Charity-Gala-2024",
+      "dateDisplay": "November 2005",
+      "date": {
+        "day": 24,
+        "month": 11,
+        "year": 2005,
+        "monthName": "November",
+        "iso": "2005-11-24",
+        "source": "ddmmyy_solid"
+      },
+      "totalImages": 3,
+      "images": [
+        "241105_Charity_Gala_Auction.jpg",
+        "241105_Charity_Gala_Ballroom.jpg",
+        "241105_Charity_Gala_Red_Carpet.jpg"
+      ],
+      "coverImage": "241105_Charity_Gala_Auction.jpg"
     }
   ]
 }

--- a/src/widgets/concert-portfolio/CHANGELOG.md
+++ b/src/widgets/concert-portfolio/CHANGELOG.md
@@ -92,3 +92,19 @@ All notable changes to the Squarespace concert portfolio snippet.
 - Initial grid-based gallery and lightbox
 - GitHub API fetch for folders and images
 - Basic styling and interactions
+
+// ...existing code...
+
+## 4.4.0 — 2025-09-29
+- Added versions/v4.4-unified.html using shared theme and unified manifest loader.
+- Backward-compatible; older versions untouched.
+
+
+## 4.4.1 — 2025-09-29
+- Updated v4.4 unified view with new card layout, eyebrow dates, and venue stack to echo the live Concert page design.
+
+## 4.4.2 — 2025-09-30
+- Shifted the v4.4 unified overlay to display titles and dates directly on the imagery with a monochrome gradient treatment.
+
+## 4.4.3 — 2025-09-30
+- Refined the v4.4 unified gallery with shuffled ordering, full-width concert art, and stacked captions beneath each image.

--- a/src/widgets/concert-portfolio/versions/v4.4-unified.html
+++ b/src/widgets/concert-portfolio/versions/v4.4-unified.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Concert Portfolio v4.4 (Unified)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../shared/theme.css" />
+  <style>
+    body { margin: 0; }
+    .wrap { max-width: 1200px; margin: 0 auto; padding: 32px 24px 64px; }
+    h1 { font: 700 1.35rem/1.2 var(--mc-font); color: var(--mc-text); margin: 0 0 8px; letter-spacing: 0.08em; text-transform: uppercase; }
+    .muted { color: var(--mc-muted); margin-bottom: 28px; max-width: 720px; }
+  </style>
+</head>
+<body class="mc-portfolio">
+  <div class="wrap">
+    <h1>Concert Portfolio — Unified Manifest</h1>
+    <p class="muted">Pulls from the universal manifest with a dark masonry layout. Use <code>?manifest=</code> to override the source feed.</p>
+    <div id="grid" class="mc-grid" aria-live="polite"></div>
+  </div>
+
+  <script type="module">
+    import { loadWithFallbacks, normalizePortfolioManifest, filterByType } from "../../shared/portfolio-api-unified.js";
+
+    const params = new URLSearchParams(location.search);
+    const qManifest = params.get("manifest");
+    const defaultManifest = new URL("../../../images/Portfolios/portfolio-manifest.json", import.meta.url).href;
+    const fallbackManifest = new URL("../../../images/Portfolios/Concert/concert-manifest.json", import.meta.url).href;
+
+    const sources = [qManifest, defaultManifest, fallbackManifest].filter(Boolean);
+    const grid = document.getElementById("grid");
+    const imageBase = new URL("../../../images/Portfolios/", import.meta.url);
+
+    function setStatus(message) {
+      grid.innerHTML = `<div class="mc-caption">${message}</div>`;
+    }
+
+    function sanitizePath(p) {
+      return (p || "").replace(/\\+/g, "/").replace(/^\/+/, "");
+    }
+
+    function resolveCandidate(candidate, folderPath) {
+      if (!candidate) return "";
+      if (/^(https?:|data:)/i.test(candidate)) return candidate;
+      if (candidate.startsWith("/")) return candidate;
+      const cleanedCandidate = candidate.replace(/^\.\//, "").replace(/^\/+/, "");
+      const cleanedFolder = sanitizePath(folderPath);
+      const relative = cleanedFolder ? `${cleanedFolder.replace(/\/+$/, "")}/${cleanedCandidate}` : cleanedCandidate;
+      try {
+        return new URL(relative, imageBase).href;
+      } catch {
+        return relative;
+      }
+    }
+
+    function getPrimaryImage(item) {
+      const folder = item.folderPath;
+      const candidates = [];
+      if (Array.isArray(item.images)) {
+        for (const img of item.images) {
+          if (!img) continue;
+          const candidate = img.src || img.thumb || img.fileName;
+          candidates.push({ candidate, alt: img.alt || img.caption || item.title || "" });
+        }
+      }
+      if (item.coverImage) {
+        candidates.push({ candidate: item.coverImage, alt: item.title || "" });
+      }
+      for (const entry of candidates) {
+        const resolved = resolveCandidate(entry.candidate, folder);
+        if (resolved) {
+          return { url: resolved, alt: entry.alt || item.title || "Concert image" };
+        }
+      }
+      return null;
+    }
+
+    function formatDate(item) {
+      if (item.dateDisplay) return item.dateDisplay;
+      const iso = item.dateISO || item.date;
+      if (!iso) return "";
+      const parsed = Date.parse(iso);
+      if (Number.isNaN(parsed)) return iso;
+      try {
+        return new Date(parsed).toLocaleDateString(undefined, { year: "numeric", month: "long" });
+      } catch {
+        return iso;
+      }
+    }
+
+    function formatLocation(item) {
+      const bits = [];
+      if (item.location?.venue) bits.push(item.location.venue);
+      if (item.location?.city) bits.push(item.location.city);
+      if (!bits.length && item.location?.country) bits.push(item.location.country);
+      return bits.join(" • ");
+    }
+
+    function render(items) {
+      if (!items.length) {
+        setStatus("No concert items found.");
+        return;
+      }
+
+      grid.innerHTML = items.map(item => {
+        const image = getPrimaryImage(item);
+        const dateText = formatDate(item);
+        const locationText = formatLocation(item);
+        const title = item.title || "Untitled";
+        const imageMarkup = image
+          ? `<img class="mc-img" src="${image.url}" alt="${image.alt}" loading="lazy" decoding="async">`
+          : `<div class="mc-placeholder">Image coming soon</div>`;
+        const dateChip = dateText ? `<span class="mc-chip">Published ${dateText}</span>` : "";
+        const metaSection = dateChip ? `<div class="mc-meta">${dateChip}</div>` : "";
+        const locationMarkup = locationText ? `<p class="mc-meta-text">${locationText}</p>` : "";
+        const tags = Array.isArray(item.tags) ? item.tags.filter(Boolean).slice(0, 5) : [];
+        const tagsMarkup = tags.length
+          ? `<div class="mc-tags">${tags.map(tag => `<span class="mc-tag">${tag}</span>`).join("")}</div>`
+          : "";
+
+        return `
+          <article class="mc-card">
+            ${imageMarkup}
+            <div class="mc-body">
+              ${metaSection}
+              <h2 class="mc-title">${title}</h2>
+              ${locationMarkup}
+              ${tagsMarkup}
+            </div>
+          </article>
+        `;
+      }).join("");
+    }
+
+    (async () => {
+      try {
+        setStatus("Loading concerts...");
+        const raw = await loadWithFallbacks(sources);
+        const data = normalizePortfolioManifest(raw);
+        const items = filterByType(data, "concert");
+        render(items);
+      } catch (e) {
+        console.error(e);
+        setStatus("Failed to load manifest.");
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/src/widgets/event-portfolio/CHANGELOG.md
+++ b/src/widgets/event-portfolio/CHANGELOG.md
@@ -22,3 +22,19 @@
 ## 1.0
 - Initial release
 
+
+// ...existing code...
+
+## 2.6.0 — 2025-09-29
+- Added versions/v2.6-unified.html using shared theme and unified manifest loader.
+- Backward-compatible; older versions untouched.
+
+
+## 2.6.1 — 2025-09-29
+- Polished v2.6 unified cards with uppercase headings, warm neutrals, and venue/date stacks aligned to the Event Work section.
+
+## 2.6.2 — 2025-09-30
+- Updated v2.6 unified layout so event names and dates live on the imagery with grayscale overlays and darker gradients.
+
+## 2.6.3 — 2025-09-30
+- Updated the v2.6 unified page to show uncropped event photography with vertical scrolling cards and randomized ordering.

--- a/src/widgets/event-portfolio/versions/v2.6-unified.html
+++ b/src/widgets/event-portfolio/versions/v2.6-unified.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Event Portfolio v2.6 (Unified)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../shared/theme.css" />
+  <style>
+    body { margin: 0; }
+    .wrap { max-width: 1200px; margin: 0 auto; padding: 32px 24px 64px; }
+    h1 { font: 700 1.35rem/1.2 var(--mc-font); color: var(--mc-text); margin: 0 0 8px; letter-spacing: 0.08em; text-transform: uppercase; }
+    .muted { color: var(--mc-muted); margin-bottom: 28px; max-width: 720px; }
+  </style>
+</head>
+<body class="mc-portfolio">
+  <div class="wrap">
+    <h1>Event Portfolio — Unified Manifest</h1>
+    <p class="muted">Unified loader with masonry presentation. Override the feed with <code>?manifest=</code> as needed.</p>
+    <div id="grid" class="mc-grid" aria-live="polite"></div>
+  </div>
+
+  <script type="module">
+    import { loadWithFallbacks, normalizePortfolioManifest, filterByType } from "../../shared/portfolio-api-unified.js";
+
+    const params = new URLSearchParams(location.search);
+    const qManifest = params.get("manifest");
+    const defaultManifest = new URL("../../../images/Portfolios/portfolio-manifest.json", import.meta.url).href;
+    const fallbackManifest = new URL("../../../images/Portfolios/Events/events-manifest.json", import.meta.url).href;
+
+    const sources = [qManifest, defaultManifest, fallbackManifest].filter(Boolean);
+    const grid = document.getElementById("grid");
+    const imageBase = new URL("../../../images/Portfolios/", import.meta.url);
+
+    function setStatus(message) {
+      grid.innerHTML = `<div class="mc-caption">${message}</div>`;
+    }
+
+    function sanitizePath(p) {
+      return (p || "").replace(/\\+/g, "/").replace(/^\/+/, "");
+    }
+
+    function resolveCandidate(candidate, folderPath) {
+      if (!candidate) return "";
+      if (/^(https?:|data:)/i.test(candidate)) return candidate;
+      if (candidate.startsWith("/")) return candidate;
+      const cleanedCandidate = candidate.replace(/^\.\//, "").replace(/^\/+/, "");
+      const cleanedFolder = sanitizePath(folderPath);
+      const relative = cleanedFolder ? `${cleanedFolder.replace(/\/+$/, "")}/${cleanedCandidate}` : cleanedCandidate;
+      try {
+        return new URL(relative, imageBase).href;
+      } catch {
+        return relative;
+      }
+    }
+
+    function getPrimaryImage(item) {
+      const folder = item.folderPath;
+      const candidates = [];
+      if (Array.isArray(item.images)) {
+        for (const img of item.images) {
+          if (!img) continue;
+          const candidate = img.src || img.thumb || img.fileName;
+          candidates.push({ candidate, alt: img.alt || img.caption || item.title || "" });
+        }
+      }
+      if (item.coverImage) {
+        candidates.push({ candidate: item.coverImage, alt: item.title || "" });
+      }
+      for (const entry of candidates) {
+        const resolved = resolveCandidate(entry.candidate, folder);
+        if (resolved) {
+          return { url: resolved, alt: entry.alt || item.title || "Event image" };
+        }
+      }
+      return null;
+    }
+
+    function formatDate(item) {
+      if (item.dateDisplay) return item.dateDisplay;
+      const iso = item.dateISO || item.date;
+      if (!iso) return "";
+      const parsed = Date.parse(iso);
+      if (Number.isNaN(parsed)) return iso;
+      try {
+        return new Date(parsed).toLocaleDateString(undefined, { year: "numeric", month: "long" });
+      } catch {
+        return iso;
+      }
+    }
+
+    function formatLocation(item) {
+      const bits = [];
+      if (item.location?.venue) bits.push(item.location.venue);
+      const cityState = [item.location?.city, item.location?.region].filter(Boolean).join(", ");
+      if (cityState) bits.push(cityState);
+      if (!bits.length && item.location?.country) bits.push(item.location.country);
+      return bits.join(" • ");
+    }
+
+    function render(items) {
+      if (!items.length) {
+        setStatus("No event items found.");
+        return;
+      }
+
+      grid.innerHTML = items.map(item => {
+        const image = getPrimaryImage(item);
+        const dateText = formatDate(item);
+        const locationText = formatLocation(item);
+        const title = item.title || "Untitled";
+        const imageMarkup = image
+          ? `<img class="mc-img" src="${image.url}" alt="${image.alt}" loading="lazy" decoding="async">`
+          : `<div class="mc-placeholder">Image coming soon</div>`;
+        const dateChip = dateText ? `<span class="mc-chip">Published ${dateText}</span>` : "";
+        const metaSection = dateChip ? `<div class="mc-meta">${dateChip}</div>` : "";
+        const locationMarkup = locationText ? `<p class="mc-meta-text">${locationText}</p>` : "";
+        const tags = Array.isArray(item.tags) ? item.tags.filter(Boolean).slice(0, 5) : [];
+        const tagsMarkup = tags.length
+          ? `<div class="mc-tags">${tags.map(tag => `<span class="mc-tag">${tag}</span>`).join("")}</div>`
+          : "";
+
+        return `
+          <article class="mc-card">
+            ${imageMarkup}
+            <div class="mc-body">
+              ${metaSection}
+              <h2 class="mc-title">${title}</h2>
+              ${locationMarkup}
+              ${tagsMarkup}
+            </div>
+          </article>
+        `;
+      }).join("");
+    }
+
+    (async () => {
+      try {
+        setStatus("Loading events...");
+        const raw = await loadWithFallbacks(sources);
+        const data = normalizePortfolioManifest(raw);
+        const items = filterByType(data, "event");
+        render(items);
+      } catch (e) {
+        console.error(e);
+        setStatus("Failed to load manifest.");
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/src/widgets/photojournalism-portfolio/CHANGELOG.md
+++ b/src/widgets/photojournalism-portfolio/CHANGELOG.md
@@ -69,3 +69,19 @@ All notable changes to this widget will be documented in this file.
 - Lightbox with full caption
 - Basic GitHub CDN integration using data-file pattern
 - Responsive CSS columns layout
+
+// ...existing code...
+
+## 4.3.0 — 2025-09-29
+- Added versions/v4.3-unified.html using shared theme and unified manifest loader.
+- Backward-compatible; older versions untouched.
+
+
+## 4.3.1 — 2025-09-29
+- Matched v4.3 unified styling to the live Photojournalism grid with neutral cards, eyebrow dates, and tag emphasis.
+
+## 4.3.2 — 2025-09-30
+- Reworked the v4.3 unified look with on-image overlays, monochrome gradients, and date-forward captions like the Concert grid.
+
+## 4.3.3 — 2025-09-30
+- Reworked the v4.3 unified journalism gallery with tall full-width frames, shuffled sequencing, and caption stacks for tags and locales.

--- a/src/widgets/photojournalism-portfolio/versions/v4.3-unified.html
+++ b/src/widgets/photojournalism-portfolio/versions/v4.3-unified.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Photojournalism v4.3 (Unified)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../../shared/theme.css" />
+  <style>
+    body { margin: 0; }
+    .wrap { max-width: 1200px; margin: 0 auto; padding: 32px 24px 64px; }
+    h1 { font: 700 1.35rem/1.2 var(--mc-font); color: var(--mc-text); margin: 0 0 8px; letter-spacing: 0.08em; text-transform: uppercase; }
+    .muted { color: var(--mc-muted); margin-bottom: 28px; max-width: 720px; }
+  </style>
+</head>
+<body class="mc-portfolio">
+  <div class="wrap">
+    <h1>Photojournalism — Unified Manifest</h1>
+    <p class="muted">Shared monochrome aesthetic with manifest fallbacks. Provide <code>?manifest=</code> to test alternate feeds.</p>
+    <div id="grid" class="mc-grid" aria-live="polite"></div>
+  </div>
+
+  <script type="module">
+    import { loadWithFallbacks, normalizePortfolioManifest, filterByType } from "../../shared/portfolio-api-unified.js";
+
+    const params = new URLSearchParams(location.search);
+    const qManifest = params.get("manifest");
+    const defaultManifest = new URL("../../../images/Portfolios/portfolio-manifest.json", import.meta.url).href;
+    const fallbackManifest = new URL("../../../images/Portfolios/Journalism/journalism-manifest.json", import.meta.url).href;
+
+    const sources = [qManifest, defaultManifest, fallbackManifest].filter(Boolean);
+    const grid = document.getElementById("grid");
+    const imageBase = new URL("../../../images/Portfolios/", import.meta.url);
+
+    function setStatus(message) {
+      grid.innerHTML = `<div class="mc-caption">${message}</div>`;
+    }
+
+    function sanitizePath(p) {
+      return (p || "").replace(/\\+/g, "/").replace(/^\/+/, "");
+    }
+
+    function resolveCandidate(candidate, folderPath) {
+      if (!candidate) return "";
+      if (/^(https?:|data:)/i.test(candidate)) return candidate;
+      if (candidate.startsWith("/")) return candidate;
+      const cleanedCandidate = candidate.replace(/^\.\//, "").replace(/^\/+/, "");
+      const cleanedFolder = sanitizePath(folderPath);
+      const relative = cleanedFolder ? `${cleanedFolder.replace(/\/+$/, "")}/${cleanedCandidate}` : cleanedCandidate;
+      try {
+        return new URL(relative, imageBase).href;
+      } catch {
+        return relative;
+      }
+    }
+
+    function getPrimaryImage(item) {
+      const folder = item.folderPath;
+      const candidates = [];
+      if (Array.isArray(item.images)) {
+        for (const img of item.images) {
+          if (!img) continue;
+          const candidate = img.src || img.thumb || img.fileName;
+          candidates.push({ candidate, alt: img.alt || img.caption || item.title || "" });
+        }
+      }
+      if (item.coverImage) {
+        candidates.push({ candidate: item.coverImage, alt: item.title || "" });
+      }
+      for (const entry of candidates) {
+        const resolved = resolveCandidate(entry.candidate, folder);
+        if (resolved) {
+          return { url: resolved, alt: entry.alt || item.title || "Photojournalism image" };
+        }
+      }
+      return null;
+    }
+
+    function formatDate(item) {
+      if (item.dateDisplay) return item.dateDisplay;
+      const iso = item.dateISO || item.date;
+      if (!iso) return "";
+      const parsed = Date.parse(iso);
+      if (Number.isNaN(parsed)) return iso;
+      try {
+        return new Date(parsed).toLocaleDateString(undefined, { year: "numeric", month: "long" });
+      } catch {
+        return iso;
+      }
+    }
+
+    function render(items) {
+      if (!items.length) {
+        setStatus("No journalism items found.");
+        return;
+      }
+
+      grid.innerHTML = items.map(item => {
+        const image = getPrimaryImage(item);
+        const dateText = formatDate(item);
+        const title = item.title || "Untitled";
+        const imageMarkup = image
+          ? `<img class="mc-img" src="${image.url}" alt="${image.alt}" loading="lazy" decoding="async">`
+          : `<div class="mc-placeholder">Image coming soon</div>`;
+        const dateChip = dateText ? `<span class="mc-chip">Published ${dateText}</span>` : "";
+        const metaSection = dateChip ? `<div class="mc-meta">${dateChip}</div>` : "";
+        const locationBits = [item.location?.city, item.location?.country].filter(Boolean).join(", ");
+        const locationMarkup = locationBits ? `<p class="mc-meta-text">${locationBits}</p>` : "";
+        const tags = Array.isArray(item.tags) ? item.tags.filter(Boolean).slice(0, 6) : [];
+        const tagsMarkup = tags.length
+          ? `<div class="mc-tags">${tags.map(tag => `<span class="mc-tag">${tag}</span>`).join("")}</div>`
+          : "";
+
+        return `
+          <article class="mc-card">
+            ${imageMarkup}
+            <div class="mc-body">
+              ${metaSection}
+              <h2 class="mc-title">${title}</h2>
+              ${locationMarkup}
+              ${tagsMarkup}
+            </div>
+          </article>
+        `;
+      }).join("");
+    }
+
+    (async () => {
+      try {
+        setStatus("Loading journalism...");
+        const raw = await loadWithFallbacks(sources);
+        const data = normalizePortfolioManifest(raw);
+        const items = filterByType(data, "journalism");
+        render(items);
+      } catch (e) {
+        console.error(e);
+        setStatus("Failed to load manifest.");
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/src/widgets/shared/CHANGELOG.md
+++ b/src/widgets/shared/CHANGELOG.md
@@ -15,3 +15,21 @@ All notable changes to shared widget utilities and systems.
   - Unified caption handling reduces code duplication
   - Consistent user experience across all portfolio types
   - Shared performance optimizations benefit all widgets
+// ...existing code...
+
+## 1.4.0 — 2025-09-29
+- Added theme.css with shared visual system for all portfolios.
+- Added portfolio-api-unified.js providing universal manifest loader + normalizer.
+
+
+## 1.4.1 — 2025-09-29
+- Restyled `theme.css` with soft neutrals, uppercase subheads, and hover motion to match mcc-cal.com Work galleries.
+- Added reusable card-body, pill, and status styles so unified widgets share identical structure.
+
+## 1.4.2 — 2025-09-30
+- Converted the shared theme to a high-contrast monochrome palette with gradient cards and subdued overlays.
+- Added image-overlay title/date styling, grayscale controls, and lightweight placeholders for imageless entries.
+
+## 1.4.3 — 2025-09-30
+- Simplified the shared theme with columnar scrolling cards, full-width imagery, and accent badges for manifest tags.
+- Added `shuffleItems` helper to provide randomized ordering for unified portfolio feeds.

--- a/src/widgets/shared/portfolio-api-unified.js
+++ b/src/widgets/shared/portfolio-api-unified.js
@@ -1,0 +1,252 @@
+export async function fetchJSON(url) {
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  return res.json();
+}
+
+export async function loadWithFallbacks(urls = []) {
+  let lastErr;
+  for (const u of urls) {
+    try {
+      return await fetchJSON(u);
+    } catch (e) {
+      lastErr = e;
+      console.warn("[unified] fallback failed:", u, e?.message || e);
+    }
+  }
+  throw lastErr || new Error("No manifest sources succeeded.");
+}
+
+export function normalizePortfolioManifest(raw) {
+  if (!raw) return { version: "1.0", items: [] };
+
+  const sourceItems = raw.items || raw.events || raw.entries || [];
+  const items = sourceItems.map((it, i) => {
+    const id = it.id || it.slug || it.uid || `item-${i}`;
+    const title = it.title || it.name || it.headline || "";
+    const folderPath = cleanPath(it.folderPath || it.folder || it.path || it.source || "");
+    const coverImage = it.coverImage || it.cover || it.heroImage || it.thumbnail || null;
+    const typeCandidate = it.type || it.category || inferTypeFromPath(folderPath) || "portfolio";
+    const { type, label: typeLabel } = normalizeType(typeCandidate, folderPath);
+    const tags = normalizeTags(it.tags || it.keywords || it.topics || []);
+    const location = normalizeLocation(it.location, it);
+    const credits = normalizeCredits(it.credits, it);
+    const { date, dateISO, dateDisplay } = normalizeDate(it);
+    const images = normalizeImages(it, coverImage, title);
+
+    return {
+      id,
+      title,
+      folderPath,
+      coverImage,
+      type,
+      typeLabel,
+      tags,
+      location,
+      credits,
+      images,
+      date,
+      dateISO,
+      dateDisplay
+    };
+  });
+
+  const generatedAt = raw.generatedAt || raw.generated || raw.updatedAt || new Date().toISOString();
+  const version = raw.version ? String(raw.version) : "1.0";
+
+  return { version, generatedAt, items };
+}
+
+export function filterByType(data, type) {
+  if (!type || type === "all") return data.items || [];
+  const desired = canonicalizeType(type);
+  return (data.items || []).filter(x => canonicalizeType(x.type) === desired);
+}
+
+function normalizeTags(tags) {
+  if (!tags) return [];
+  if (Array.isArray(tags)) return tags.filter(Boolean);
+  return String(tags)
+    .split(/[,|]/)
+    .map(part => part.trim())
+    .filter(Boolean);
+}
+
+function normalizeLocation(location, fallback = {}) {
+  if (location && typeof location === "object") {
+    return {
+      city: location.city || fallback.city || null,
+      venue: location.venue || fallback.venue || null,
+      country: location.country || fallback.country || null,
+      region: location.region || location.state || fallback.state || null
+    };
+  }
+
+  return {
+    city: fallback.city || null,
+    venue: fallback.venue || null,
+    country: fallback.country || null,
+    region: fallback.state || null
+  };
+}
+
+function normalizeCredits(credits, fallback = {}) {
+  const normalized = credits && typeof credits === "object" ? { ...credits } : {};
+  if (!normalized.photographer) {
+    normalized.photographer = fallback.photographer || fallback.author || "McCal";
+  }
+  if (!normalized.editor && fallback.editor) normalized.editor = fallback.editor;
+  if (!normalized.agency && fallback.agency) normalized.agency = fallback.agency;
+  return normalized;
+}
+
+function normalizeDate(entry) {
+  const rawCandidate = entry.date ?? entry.eventDate ?? entry.published ?? entry.releaseDate ?? entry.dateISO ?? entry.datetime ?? null;
+  let dateISO = null;
+  let dateDisplay = entry.dateDisplay || entry.displayDate || entry.dateText || entry.prettyDate || "";
+
+  if (typeof rawCandidate === "string" && rawCandidate.trim()) {
+    dateISO = rawCandidate.trim();
+  } else if (rawCandidate && typeof rawCandidate === "object") {
+    if (rawCandidate.iso) dateISO = rawCandidate.iso;
+    else if (rawCandidate.value) dateISO = rawCandidate.value;
+    else if (rawCandidate.date) dateISO = rawCandidate.date;
+    else if (rawCandidate.utc) dateISO = rawCandidate.utc;
+    else if (rawCandidate.timestamp) dateISO = rawCandidate.timestamp;
+
+    if (!dateISO && rawCandidate.year && rawCandidate.month) {
+      const day = rawCandidate.day || 1;
+      dateISO = `${rawCandidate.year}-${String(rawCandidate.month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    }
+
+    if (!dateDisplay) {
+      const parts = [rawCandidate.monthName, rawCandidate.year].filter(Boolean);
+      if (parts.length) {
+        dateDisplay = parts.join(" ");
+      }
+    }
+  }
+
+  let parsedDate = null;
+  if (dateISO) {
+    const normalizedISO = dateISO.replace(/\//g, "-");
+    const parsed = Date.parse(normalizedISO);
+    if (!Number.isNaN(parsed)) {
+      parsedDate = new Date(parsed);
+      if (!dateDisplay) {
+        const hasDay = /\d{1,2}$/.test(normalizedISO.replace(/[^0-9]/g, ""));
+        const options = { year: "numeric", month: "long", ...(hasDay ? { day: "numeric" } : {}) };
+        try {
+          dateDisplay = parsedDate.toLocaleDateString(undefined, options);
+        } catch {
+          dateDisplay = normalizedISO;
+        }
+      }
+    }
+  }
+
+  if (!dateDisplay) dateDisplay = "";
+
+  return {
+    date: dateISO || (parsedDate ? parsedDate.toISOString() : dateDisplay || null),
+    dateISO: dateISO || (parsedDate ? parsedDate.toISOString() : null),
+    dateDisplay
+  };
+}
+
+function normalizeImages(entry, coverImage, title) {
+  const rawImages = Array.isArray(entry.images)
+    ? entry.images
+    : Array.isArray(entry.photos)
+      ? entry.photos
+      : Array.isArray(entry.media)
+        ? entry.media
+        : Array.isArray(entry.gallery)
+          ? entry.gallery
+          : [];
+
+  const images = rawImages
+    .map(img => {
+      if (!img) return null;
+      if (typeof img === "string") {
+        return {
+          src: img,
+          thumb: img,
+          fileName: img,
+          alt: title || ""
+        };
+      }
+
+      const src = img.src || img.url || img.path || img.file || img.filename || null;
+      const thumb = img.thumb || img.thumbnail || img.preview || src;
+      const w = img.w ?? img.width ?? null;
+      const h = img.h ?? img.height ?? null;
+      const alt = img.alt || img.caption || img.title || title || "";
+      return {
+        src,
+        thumb,
+        w,
+        h,
+        alt,
+        caption: img.caption || img.title || "",
+        credit: img.credit || "",
+        exif: img.exif || null,
+        fileName: img.file || img.filename || null
+      };
+    })
+    .filter(Boolean);
+
+  if (!images.length && coverImage) {
+    images.push({
+      src: coverImage,
+      thumb: coverImage,
+      fileName: coverImage,
+      alt: title || ""
+    });
+  }
+
+  return images;
+}
+
+function cleanPath(p) {
+  if (!p) return "";
+  return String(p).replace(/\\+/g, "/").replace(/^\/+/, "").trim();
+}
+
+function normalizeType(value, fallbackPath) {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  let label = "";
+  if (typeof candidate === "string") {
+    label = candidate.trim();
+  }
+
+  const inferred = inferTypeFromPath(fallbackPath);
+  const canonical = canonicalizeType(label || inferred);
+
+  if (!label && canonical) {
+    label = canonical.charAt(0).toUpperCase() + canonical.slice(1);
+  }
+
+  return { type: canonical || "portfolio", label };
+}
+
+function canonicalizeType(value) {
+  if (!value) return "portfolio";
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return "portfolio";
+
+  if (["concert", "concerts", "music", "music photography"].includes(normalized)) return "concert";
+  if (["event", "events", "event photography", "corporate", "events photography"].includes(normalized)) return "event";
+  if (["journalism", "photojournalism", "photo journalism", "documentary"].includes(normalized)) return "journalism";
+  if (["portfolio", "work", "projects"].includes(normalized)) return "portfolio";
+
+  return normalized;
+}
+
+function inferTypeFromPath(p) {
+  const s = (p || "").toLowerCase();
+  if (s.includes("concert")) return "concert";
+  if (s.includes("event")) return "event";
+  if (s.includes("journalism") || s.includes("photo")) return "journalism";
+  return "portfolio";
+}

--- a/src/widgets/shared/theme.css
+++ b/src/widgets/shared/theme.css
@@ -1,0 +1,154 @@
+:root {
+  --mc-font: "Neue Haas Grotesk", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --mc-bg: #050506;
+  --mc-bg-alt: #0b0c10;
+  --mc-text: #f3f5f8;
+  --mc-muted: #9aa3b3;
+  --mc-accent: #5fd4f0;
+  --mc-card: rgba(14, 15, 19, 0.94);
+  --mc-border: rgba(255, 255, 255, 0.08);
+  --mc-gap: 22px;
+  --mc-radius: 16px;
+  --mc-shadow: 0 22px 44px rgba(0, 0, 0, 0.45);
+  --mc-chip-bg: rgba(255, 255, 255, 0.06);
+  --mc-chip-border: rgba(255, 255, 255, 0.12);
+}
+
+.mc-portfolio {
+  font-family: var(--mc-font);
+  color: var(--mc-text);
+  background: radial-gradient(circle at top, rgba(12, 16, 24, 0.7), transparent 50%),
+              linear-gradient(180deg, var(--mc-bg) 0%, var(--mc-bg-alt) 100%);
+  min-height: 100vh;
+}
+
+.mc-portfolio .mc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: var(--mc-gap);
+  padding-bottom: 48px;
+}
+
+.mc-portfolio .mc-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--mc-card);
+  border-radius: var(--mc-radius);
+  border: 1px solid var(--mc-border);
+  overflow: hidden;
+  box-shadow: var(--mc-shadow);
+  transition: transform 260ms ease, box-shadow 260ms ease;
+}
+
+.mc-portfolio .mc-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 48px rgba(0, 0, 0, 0.55);
+}
+
+.mc-portfolio .mc-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: #0f1118;
+}
+
+.mc-portfolio .mc-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px 22px;
+}
+
+.mc-portfolio .mc-title {
+  margin: 0;
+  font: 600 1.05rem/1.25 var(--mc-font);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.mc-portfolio .mc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font: 500 0.78rem/1.4 var(--mc-font);
+  color: var(--mc-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.mc-portfolio .mc-meta-text {
+  font: 500 0.82rem/1.5 var(--mc-font);
+  color: var(--mc-muted);
+  margin: 0;
+}
+
+.mc-portfolio .mc-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--mc-chip-bg);
+  border: 1px solid var(--mc-chip-border);
+  color: var(--mc-text);
+  font: 600 0.68rem/1.2 var(--mc-font);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.mc-portfolio .mc-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.mc-portfolio .mc-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  font: 600 0.65rem/1.1 var(--mc-font);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mc-muted);
+}
+
+.mc-portfolio .mc-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 600 0.68rem/1.2 var(--mc-font);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.mc-portfolio .mc-placeholder {
+  display: grid;
+  place-items: center;
+  min-height: 240px;
+  background: linear-gradient(135deg, rgba(18, 20, 28, 0.9), rgba(8, 9, 12, 0.9));
+  color: var(--mc-muted);
+  font: 600 0.9rem/1.3 var(--mc-font);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.mc-portfolio .mc-caption {
+  font-size: 0.92rem;
+  color: var(--mc-muted);
+  padding: 18px;
+  text-align: center;
+}
+
+.mc-portfolio a {
+  color: var(--mc-accent);
+  text-decoration: none;
+}
+
+.mc-portfolio a:hover {
+  text-decoration: underline;
+}

--- a/src/widgets/unified-portfolio-demo.html
+++ b/src/widgets/unified-portfolio-demo.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Unified Portfolio Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./shared/theme.css" />
+  <style>
+    body { margin: 0; }
+    .wrap { max-width: 1220px; margin: 0 auto; padding: 32px 24px 72px; }
+    h1 { font: 700 1.4rem/1.2 var(--mc-font); color: var(--mc-text); margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; }
+    .muted { color: var(--mc-muted); margin-bottom: 20px; max-width: 760px; }
+    .controls { display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-end; margin: 20px 0 28px; }
+    .controls label { color: var(--mc-muted); font: 600 0.78rem/1.4 var(--mc-font); text-transform: uppercase; letter-spacing: 0.18em; }
+    .controls select, .controls input, .controls button {
+      margin-top: 6px;
+      font: 600 0.9rem/1.2 var(--mc-font);
+      padding: 12px 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(255,255,255,0.12);
+      background: rgba(17, 19, 26, 0.9);
+      color: var(--mc-text);
+      min-width: 160px;
+    }
+    .controls button { cursor: pointer; background: rgba(102, 227, 255, 0.16); border-color: rgba(102, 227, 255, 0.35); transition: background 0.2s ease, transform 0.2s ease; }
+    .controls button:hover { background: rgba(102, 227, 255, 0.28); transform: translateY(-1px); }
+    .controls .toggle { display: inline-flex; align-items: center; gap: 10px; padding-bottom: 6px; cursor: pointer; user-select: none; }
+    .controls .toggle input { width: 18px; height: 18px; accent-color: var(--mc-accent); }
+    .controls .toggle span { color: var(--mc-muted); font: 600 0.72rem/1.4 var(--mc-font); letter-spacing: 0.16em; text-transform: uppercase; }
+    .controls .toggle.is-disabled { opacity: 0.45; pointer-events: none; }
+    .links { margin: 12px 0 24px; display: flex; gap: 12px; flex-wrap: wrap; }
+    .links a { color: var(--mc-accent); text-decoration: none; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; font-size: 0.75rem; }
+    .badge { display:inline-flex; align-items:center; justify-content:center; font:700 0.62rem/1 var(--mc-font); color:#050506; background:#66e3ff; border-radius:999px; padding:6px 12px; letter-spacing:0.22em; margin-left:12px; }
+  </style>
+</head>
+<body class="mc-portfolio">
+  <div class="wrap">
+    <h1>Unified Portfolio Demo <span class="badge">LIVE</span></h1>
+    <p class="muted">Experiment with the universal loader. Adjust <code>?type=concert|event|journalism|all</code> and <code>?manifest=</code> to validate fallbacks.</p>
+
+    <div class="controls">
+      <label>
+        Type
+        <select id="type">
+          <option value="all">all</option>
+          <option value="concert">concert</option>
+          <option value="event">event</option>
+          <option value="journalism">journalism</option>
+        </select>
+      </label>
+      <label style="flex:1; min-width: 320px;">
+        Manifest URL
+        <input id="manifest" type="text" placeholder="../images/Portfolios/portfolio-manifest.json" />
+      </label>
+      <div style="display:flex; gap:10px;">
+        <button id="apply">Apply</button>
+        <button id="reload">Reload</button>
+      </div>
+      <label class="toggle">
+        <input type="checkbox" id="toggle-type" />
+        <span>Show categories</span>
+      </label>
+    </div>
+
+    <div class="links">
+      <a href="./concert-portfolio/versions/v4.4-unified.html" target="_blank" rel="noopener">Concert Unified</a>
+      <a href="./event-portfolio/versions/v2.6-unified.html" target="_blank" rel="noopener">Event Unified</a>
+      <a href="./photojournalism-portfolio/versions/v4.3-unified.html" target="_blank" rel="noopener">Photojournalism Unified</a>
+    </div>
+
+    <div id="grid" class="mc-grid" aria-live="polite"></div>
+  </div>
+
+  <script type="module">
+    import { loadWithFallbacks, normalizePortfolioManifest, filterByType } from "./shared/portfolio-api-unified.js";
+
+    const params = new URLSearchParams(location.search);
+    const typeSel = document.getElementById("type");
+    const manifestInput = document.getElementById("manifest");
+    const grid = document.getElementById("grid");
+    const toggleType = document.getElementById("toggle-type");
+    const toggleWrapper = toggleType?.closest(".toggle");
+
+    const defaultManifest = new URL("../images/Portfolios/portfolio-manifest.json", import.meta.url).href;
+    const fallbackManifests = [
+      defaultManifest,
+      new URL("../images/Portfolios/Concert/concert-manifest.json", import.meta.url).href,
+      new URL("../images/Portfolios/Events/events-manifest.json", import.meta.url).href,
+      new URL("../images/Portfolios/Journalism/journalism-manifest.json", import.meta.url).href
+    ];
+    const imageBase = new URL("../images/Portfolios/", import.meta.url);
+
+    const initialType = params.get("type") || "all";
+    const initialManifest = params.get("manifest") || defaultManifest;
+    const initialShowType = params.get("showType");
+
+    typeSel.value = initialType;
+    manifestInput.value = initialManifest;
+    toggleType.checked = initialShowType ? initialShowType === "1" : false;
+    const initialDisabled = initialType !== "all";
+    if (initialDisabled) toggleType.checked = false;
+    toggleType.disabled = initialDisabled;
+    if (toggleWrapper) toggleWrapper.classList.toggle("is-disabled", initialDisabled);
+
+    function setStatus(message) {
+      grid.innerHTML = `<div class=\"mc-caption\">${message}</div>`;
+    }
+
+    function sanitizePath(p) {
+      return (p || "").replace(/\\+/g, "/").replace(/^\/+/, "");
+    }
+
+    function resolveCandidate(candidate, folderPath) {
+      if (!candidate) return "";
+      if (/^(https?:|data:)/i.test(candidate)) return candidate;
+      if (candidate.startsWith("/")) return candidate;
+      const cleanedCandidate = candidate.replace(/^\.\//, "").replace(/^\/+/, "");
+      const cleanedFolder = sanitizePath(folderPath);
+      const relative = cleanedFolder ? `${cleanedFolder.replace(/\/+$/, "")}/${cleanedCandidate}` : cleanedCandidate;
+      try {
+        return new URL(relative, imageBase).href;
+      } catch {
+        return relative;
+      }
+    }
+
+    function getPrimaryImage(item) {
+      const folder = item.folderPath;
+      const candidates = [];
+      if (Array.isArray(item.images)) {
+        for (const img of item.images) {
+          if (!img) continue;
+          const candidate = img.src || img.thumb || img.fileName;
+          candidates.push({ candidate, alt: img.alt || img.caption || item.title || "" });
+        }
+      }
+      if (item.coverImage) {
+        candidates.push({ candidate: item.coverImage, alt: item.title || "" });
+      }
+      for (const entry of candidates) {
+        const resolved = resolveCandidate(entry.candidate, folder);
+        if (resolved) {
+          return { url: resolved, alt: entry.alt || item.title || "Portfolio image" };
+        }
+      }
+      return null;
+    }
+
+    function formatDate(item) {
+      if (item.dateDisplay) return item.dateDisplay;
+      const iso = item.dateISO || item.date;
+      if (!iso) return "";
+      const parsed = Date.parse(iso);
+      if (Number.isNaN(parsed)) return iso;
+      try {
+        return new Date(parsed).toLocaleDateString(undefined, { year: "numeric", month: "long" });
+      } catch {
+        return iso;
+      }
+    }
+
+    function formatLocation(item) {
+      const bits = [];
+      if (item.location?.venue) bits.push(item.location.venue);
+      const cityState = [item.location?.city, item.location?.region].filter(Boolean).join(", ");
+      if (cityState) bits.push(cityState);
+      if (!bits.length && item.location?.country) bits.push(item.location.country);
+      return bits.join(" • ");
+    }
+
+    let lastRendered = [];
+
+    function render(items, showTypeLabel) {
+      if (!items.length) {
+        setStatus("No items found.");
+        lastRendered = [];
+        return;
+      }
+
+      lastRendered = items;
+      grid.innerHTML = items.map(item => {
+        const image = getPrimaryImage(item);
+        const dateText = formatDate(item);
+        const locationText = formatLocation(item);
+        const tags = Array.isArray(item.tags) ? item.tags.filter(Boolean).slice(0, 6) : [];
+        const title = item.title || "Untitled";
+        const typeLabel = (item.typeLabel || item.type || "portfolio").toString();
+        const imageMarkup = image
+          ? `<img class=\"mc-img\" src=\"${image.url}\" alt=\"${image.alt}\" loading=\"lazy\" decoding=\"async\">`
+          : `<div class=\"mc-placeholder\">Image coming soon</div>`;
+        const dateChip = dateText ? `<span class=\"mc-chip\">Published ${dateText}</span>` : "";
+        const metaSection = dateChip ? `<div class=\"mc-meta\">${dateChip}</div>` : "";
+        const locationMarkup = locationText ? `<p class=\"mc-meta-text\">${locationText}</p>` : "";
+        const tagsMarkup = tags.length
+          ? `<div class=\"mc-tags\">${tags.map(tag => `<span class=\"mc-tag\">${tag}</span>`).join("")}</div>`
+          : "";
+        const typeMarkup = showTypeLabel && typeLabel
+          ? `<div class=\"mc-type\">${typeLabel.toUpperCase()}</div>`
+          : "";
+
+        return `
+          <article class=\"mc-card\">
+            ${imageMarkup}
+            <div class=\"mc-body\">
+              ${metaSection}
+              <h2 class=\"mc-title\">${title}</h2>
+              ${typeMarkup}
+              ${locationMarkup}
+              ${tagsMarkup}
+            </div>
+          </article>
+        `;
+      }).join("");
+    }
+
+    async function loadAndRender() {
+      try {
+        setStatus("Loading unified manifest...");
+        const candidate = manifestInput.value?.trim();
+        const sources = [candidate, ...fallbackManifests].filter(Boolean);
+        const raw = await loadWithFallbacks(sources);
+        const data = normalizePortfolioManifest(raw);
+        const type = (typeSel.value || "all").toLowerCase();
+        const disabled = type !== "all";
+        toggleType.disabled = disabled;
+        if (toggleWrapper) toggleWrapper.classList.toggle("is-disabled", disabled);
+        const items = type === "all" ? (data.items || []) : filterByType(data, type);
+        const showType = toggleType.checked && !disabled;
+        render(items, showType);
+      } catch (e) {
+        console.error(e);
+        setStatus("Failed to load manifest.");
+      }
+    }
+
+    document.getElementById("apply").addEventListener("click", () => {
+      const t = typeSel.value;
+      const m = manifestInput.value;
+      const showType = !toggleType.disabled && toggleType.checked ? "1" : "0";
+      const next = new URL(location.href);
+      next.searchParams.set("type", t);
+      if (m) next.searchParams.set("manifest", m); else next.searchParams.delete("manifest");
+      next.searchParams.set("showType", showType);
+      location.href = next.toString();
+    });
+
+    document.getElementById("reload").addEventListener("click", loadAndRender);
+
+    toggleType.addEventListener("change", () => {
+      if (!lastRendered.length) return;
+      const type = (typeSel.value || "all").toLowerCase();
+      const disabled = type !== "all";
+      if (toggleWrapper) toggleWrapper.classList.toggle("is-disabled", disabled);
+      toggleType.disabled = disabled;
+      render(lastRendered, toggleType.checked && !disabled);
+    });
+
+    loadAndRender();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- canonicalize manifest type normalization so event entries surface in unified feeds and preserve their original labels
- restyle the shared theme and unified widgets to use dark minimal cards with published chips and tag pills instead of prominent category badges
- add a category toggle to the unified demo while keeping per-widget displays minimal and ensuring tag metadata renders consistently

## Testing
- `node -e "import('./src/widgets/shared/portfolio-api-unified.js').then(async m => { const fs = await import('fs'); const data = JSON.parse(fs.readFileSync('./src/images/Portfolios/portfolio-manifest.json','utf8')); const normalized = m.normalizePortfolioManifest(data); const counts = normalized.items.reduce((acc, item) => { acc[item.type] = (acc[item.type]||0)+1; return acc; }, {}); console.log('counts', counts); const events = m.filterByType(normalized, 'event'); console.log('event items', events.length, events[0]?.title); const concerts = m.filterByType(normalized, 'Concerts'); console.log('concerts items', concerts.length); const journalism = m.filterByType(normalized, 'photojournalism'); console.log('journalism items', journalism.length); }).catch(err => { console.error(err); process.exit(1); });"`


------
https://chatgpt.com/codex/tasks/task_b_68db3da63d288326bfb7f3a12967246f