### PR TITLE
ci: handle multiline commit action files

### DIFF
--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -43,12 +43,16 @@ runs:
       id: commit
       if: steps.check.outputs.has_changes == 'true'
       shell: bash
+      env:
+        FILES_INPUT: ${{ inputs.files }}
       run: |
         git config --local user.email "actions@github.com"
         git config --local user.name "GitHub Actions"
         
-        # Add specified files (suppress errors for non-existent files)
-        for file in ${{ inputs.files }}; do
+        # Add specified files (suppress errors for non-existent files).
+        # The input may be provided as a multiline block or whitespace-separated list.
+        printf '%s\n' "$FILES_INPUT" | tr '[:space:]' '\n' | while IFS= read -r file; do
+          [[ -z "$file" ]] && continue
           git add "$file" 2>/dev/null || true
         done
         

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -112,6 +112,7 @@ Guardrails:
 
 - 2026-06-02: CI guard maintenance should keep `actions/github-script@v9` issue calls under `github.rest.issues`, grant `issues: write` to PR-commenting guards, keep Gitleaks checkouts deep enough for commit range scans, and use tracked static manifest fixtures in Vite tests.
 - 2026-06-02: Auto-Generate Manifests matrix entries should map to explicit root npm aliases (`manifest:nature`, `manifest:portrait`, `manifest:featured`, `manifest:universal`, etc.) instead of inline generator paths.
+- 2026-06-02: Reusable composite actions should parse multiline inputs before shell loops; do not interpolate multiline `files:` blocks directly into `for` statements.
 
 - 2026-03-30: Added a Markdown-first blog workflow under `src/content/blog/`. `post.md` is now the preferred authored source, `post.json` is generated for runtime compatibility, and Google Docs import now writes Markdown to support gradual migration off Docs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed GitHub Actions guard scripts to use the `github.rest.issues` namespace required by `actions/github-script@v9`.
 - Compacted the Auto-Generate Manifests matrix output before writing to `$GITHUB_OUTPUT`.
 - Added individual root manifest script aliases for nature, portrait, featured, and universal portfolio generators so the Auto-Generate Manifests workflow can run each matrix job.
+- Fixed the reusable commit-and-push action to parse multiline file lists before staging generated manifest artifacts.
 - Updated the Gitleaks checkout to use full history for commit range scans.
 - Adjusted the events page manifest test to read the tracked static events manifest fixture.
 


### PR DESCRIPTION
## Summary
- Parse multiline or whitespace-separated `files` inputs in the reusable commit-and-push action before staging files
- Keep the auto-manifest commit step from interpolating multiline pathspecs directly into a Bash `for` loop
- Update changelog and repo guidance for the composite action guardrail

## Verification
- `node scripts/utils/ci-validate-workflows.js`
- `npm run ci:check`
- `npm run lint`

## Follow-up Evidence
- Manual Auto-Generate Manifests run `26829483148` proved all seven generate matrix jobs pass after PR #103, then failed only in the commit step on multiline `files:` parsing.